### PR TITLE
cbpy: Fix error handling in get_sample_group

### DIFF
--- a/cerebus/cbpy.pyx
+++ b/cerebus/cbpy.pyx
@@ -910,14 +910,11 @@ def get_sample_group(int group_ix, int instance=0):
     cdef cbSdkResult res
     cdef uint32_t proc = 1
     cdef uint32_t nChansInGroup
-    res = cbSdkGetSampleGroupList(<uint32_t>instance, proc, group_ix, &nChansInGroup, NULL)
-    handle_result(res)
-    if (nChansInGroup <= 0):
-        return <int> res, []
-
     cdef uint16_t pGroupList[cbNUM_ANALOG_CHANS+0]
     res = cbSdkGetSampleGroupList(<uint32_t>instance, proc, <uint32_t>group_ix, &nChansInGroup, pGroupList)
-    handle_result(res)
+    if res:
+        handle_result(res)
+        return <int> res, []
 
     cdef cbPKT_CHANINFO chanInfo
     channels_info = []


### PR DESCRIPTION
When cbSdkGetSampleGroupList returns an error the nChansInGroup variable
is in fact uninitialized so it can be any number, and usually very large.
As such looping over range(nChansInGroup) results in problems due to
undefined behavior, for example segfaults or a ZeroDivisionError when
dividing by digRange because it is unitialized for out-of-range channels.
Fix this by producing one single error when requesting a non-existing
sample group, and returning immediately in that case. Remove the extra
call for getting the number of channels since it's incorrect to test the
nChansInGroup variable.