### PR TITLE
Include <time.h> to provide clock_gettime

### DIFF
--- a/cbhwlib/cbhwlib.cpp
+++ b/cbhwlib/cbhwlib.cpp
@@ -34,6 +34,7 @@
     #include <sys/types.h>
     #include <sys/stat.h>
     #include <unistd.h>
+    #include <time.h>
 #endif
 #endif
 #ifndef _MSC_VER


### PR DESCRIPTION
With the current git state, I cannot compile the sources on Linux, as the function clock_gettime is not defined.

When I include time.h, everything compiles again.