### PR TITLE
linux socket fixup

### DIFF
--- a/.github/workflows/build_cbsdk.yml
+++ b/.github/workflows/build_cbsdk.yml
@@ -15,9 +15,6 @@ on:
 permissions:
   contents: write
 
-env:
-  NSPVERSION: 7.5.1
-
 defaults:
   run:
     shell: bash
@@ -33,7 +30,7 @@ jobs:
           - {name: "windows-x64", os: "windows-latest",
             qt_arch: "win64_msvc2019_64", qt_ver: "6.4.3",
             cmake_extra: "-DCMAKE_PREFIX_PATH='D:\\a\\CereLink\\Qt\\6.4.3\\msvc2019_64' -T v142,host=x86"}
-          - { name: "macOS-latest", os: "macOS-latest", cibw_build: "cp3*-macosx_x86_64"}
+          - { name: "macOS-latest", os: "macOS-latest"}
           - { name: "jammy", os: "ubuntu-22.04"}
           - { name: "focal", os: "ubuntu-20.04"}
 
@@ -66,7 +63,10 @@ jobs:
         run: |
           cmake --version
           cmake -B build -S . \
+          -DBUILD_CBMEX=OFF \
+          -DBUILD_CBOCT=OFF \
           -DBUILD_TEST=OFF \
+          -DBUILD_HDF5=OFF \
           -DCMAKE_BUILD_TYPE=Release \
           -DCMAKE_INSTALL_PREFIX=${PWD}/install \
           -DCPACK_PACKAGE_DIRECTORY=${PWD}/dist \

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -467,6 +467,10 @@ if(WIN32)
             $<TARGET_RUNTIME_DLLS:${LIB_NAME}>
             TYPE BIN
     )
+elseif(APPLE)
+    install(CODE "
+        execute_process(COMMAND codesign --force --deep --sign - ${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}/lib${LIB_NAME}.dylib)
+    ")
 endif(WIN32)
 
 

--- a/Central/UDPsocket.cpp
+++ b/Central/UDPsocket.cpp
@@ -23,6 +23,7 @@ typedef int socklen_t;
 #include <arpa/inet.h>
 #include <fcntl.h>
 #include <errno.h>
+#include <string.h>
 #include <unistd.h>
 typedef struct sockaddr SOCKADDR;
 #define INVALID_SOCKET -1
@@ -415,6 +416,15 @@ cbRESULT UDPSocket::OpenTCP(STARTUP_OPTIONS nStartupOptionsFlags, int nRange, bo
 
 void UDPSocket::Close()
 {
+#ifdef WIN32
+    char errbuf[300];
+    FormatMessage(FORMAT_MESSAGE_FROM_SYSTEM, NULL, WSAGetLastError(),
+                  0, errbuf, sizeof(errbuf), NULL);
+#else
+    int sv_err = errno;
+    const char* errbuf = strerror(sv_err);
+#endif
+    fprintf(stderr, "UDP socket error: %s\n", errbuf);
     m_TCPconnected = false;
     shutdown(inst_sock, SD_BOTH); // shutdown communication
 #ifdef WIN32

--- a/Central/UDPsocket.cpp
+++ b/Central/UDPsocket.cpp
@@ -93,12 +93,11 @@ cbRESULT UDPSocket::OpenUDP(STARTUP_OPTIONS nStartupOptionsFlags, int nRange, bo
         return cbRESULT_SOCKERR;
     }
 
-    bool opt_val = true;
-    socklen_t  opt_len = sizeof(bool);
+    int opt_one = 1;
 
     if (bBroadcast)
     {
-        if (setsockopt(inst_sock, SOL_SOCKET, SO_BROADCAST, (char*)&opt_val, opt_len) != 0)
+        if (setsockopt(inst_sock, SOL_SOCKET, SO_BROADCAST, (char*)&opt_one, sizeof(opt_one)) != 0)
         {
             Close();
             return cbRESULT_SOCKOPTERR;
@@ -107,7 +106,7 @@ cbRESULT UDPSocket::OpenUDP(STARTUP_OPTIONS nStartupOptionsFlags, int nRange, bo
 
     if (bDontRoute)
     {
-        if (setsockopt(inst_sock, SOL_SOCKET, SO_DONTROUTE, (char*)&opt_val, opt_len) != 0)
+        if (setsockopt(inst_sock, SOL_SOCKET, SO_DONTROUTE, (char*)&opt_one, sizeof(opt_one)) != 0)
         {
             Close();
             return cbRESULT_SOCKOPTERR;
@@ -116,7 +115,7 @@ cbRESULT UDPSocket::OpenUDP(STARTUP_OPTIONS nStartupOptionsFlags, int nRange, bo
 
     if (OPT_REUSE == nStartupOptionsFlags)
     {
-        if (setsockopt(inst_sock, SOL_SOCKET, SO_REUSEADDR, (char*)&opt_val, opt_len) != 0)
+        if (setsockopt(inst_sock, SOL_SOCKET, SO_REUSEADDR, (char*)&opt_one, sizeof(opt_one)) != 0)
         {
             Close();
             return cbRESULT_SOCKOPTERR;
@@ -126,9 +125,8 @@ cbRESULT UDPSocket::OpenUDP(STARTUP_OPTIONS nStartupOptionsFlags, int nRange, bo
     if (nRecBufSize > 0)
     {
         // Set the data stream input buffer size
-        opt_len = sizeof(int);
         int data_buff_size = nRecBufSize;
-        if (setsockopt(inst_sock, SOL_SOCKET, SO_RCVBUF, (char*)&data_buff_size, opt_len) != 0)
+        if (setsockopt(inst_sock, SOL_SOCKET, SO_RCVBUF, (char*)&data_buff_size, sizeof(data_buff_size)) != 0)
         {
             Close();
 #ifdef __APPLE__
@@ -137,6 +135,7 @@ cbRESULT UDPSocket::OpenUDP(STARTUP_OPTIONS nStartupOptionsFlags, int nRange, bo
             return cbRESULT_SOCKOPTERR;
 #endif
         }
+        socklen_t  opt_len = sizeof(int);
         if (getsockopt(inst_sock, SOL_SOCKET, SO_RCVBUF, (char *)&data_buff_size, &opt_len) != 0)
         {
             Close();
@@ -223,8 +222,7 @@ cbRESULT UDPSocket::OpenUDP(STARTUP_OPTIONS nStartupOptionsFlags, int nRange, bo
             if (m_bVerbose)
                 _cprintf("Warning: could not bind to socket on the subnet...\n");
 
-            opt_len = sizeof(bool);
-            if (setsockopt(inst_sock, SOL_SOCKET, SO_REUSEADDR, (char*)&opt_val, opt_len) != 0)
+            if (setsockopt(inst_sock, SOL_SOCKET, SO_REUSEADDR, (char*)&opt_one, sizeof(opt_one)) != 0)
             {
                 if(m_bVerbose)
                     _cprintf("Error enabling address re-used\n");
@@ -306,15 +304,12 @@ cbRESULT UDPSocket::OpenTCP(STARTUP_OPTIONS nStartupOptionsFlags, int nRange, bo
         return cbRESULT_SOCKERR;
     }
 
-    bool opt_val = true;
-    socklen_t  opt_len = sizeof(bool);
-
     if (nRecBufSize > 0)
     {
         // Set the data stream input buffer size
-        opt_len = sizeof(int);
+
         int data_buff_size = nRecBufSize;
-        if (setsockopt(inst_sock, SOL_SOCKET, SO_RCVBUF, (char*)&data_buff_size, opt_len) != 0)
+        if (setsockopt(inst_sock, SOL_SOCKET, SO_RCVBUF, (char*)&data_buff_size, sizeof(data_buff_size)) != 0)
         {
             Close();
 #ifdef __APPLE__
@@ -323,6 +318,8 @@ cbRESULT UDPSocket::OpenTCP(STARTUP_OPTIONS nStartupOptionsFlags, int nRange, bo
             return cbRESULT_SOCKOPTERR;
 #endif
         }
+
+        socklen_t opt_len = sizeof(int);
         if (getsockopt(inst_sock, SOL_SOCKET, SO_RCVBUF, (char*)&data_buff_size, &opt_len) != 0)
         {
             Close();
@@ -349,7 +346,7 @@ cbRESULT UDPSocket::OpenTCP(STARTUP_OPTIONS nStartupOptionsFlags, int nRange, bo
     }
 
     int opt_sndbuf = nRecBufSize;
-    if (setsockopt(inst_sock, SOL_SOCKET, SO_SNDBUF, (char*)&opt_sndbuf, sizeof(int)) != 0)
+    if (setsockopt(inst_sock, SOL_SOCKET, SO_SNDBUF, (char*)&opt_sndbuf, sizeof(opt_sndbuf)) != 0)
     {
         Close();
         return cbRESULT_SOCKOPTERR;
@@ -357,7 +354,8 @@ cbRESULT UDPSocket::OpenTCP(STARTUP_OPTIONS nStartupOptionsFlags, int nRange, bo
 
     //    if (bDontRoute)
     {
-        if (setsockopt(inst_sock, SOL_SOCKET, SO_DONTROUTE, (char*)&opt_val, opt_len) != 0)
+        int opt_one = 1;
+        if (setsockopt(inst_sock, SOL_SOCKET, SO_DONTROUTE, (char*)&opt_one, sizeof(opt_one)) != 0)
         {
             Close();
             return cbRESULT_SOCKOPTERR;

--- a/Central/UDPsocket.cpp
+++ b/Central/UDPsocket.cpp
@@ -414,15 +414,20 @@ cbRESULT UDPSocket::OpenTCP(STARTUP_OPTIONS nStartupOptionsFlags, int nRange, bo
 
 void UDPSocket::Close()
 {
+    int err = 0;
 #ifdef WIN32
-    char errbuf[300];
-    FormatMessage(FORMAT_MESSAGE_FROM_SYSTEM, NULL, WSAGetLastError(),
-                  0, errbuf, sizeof(errbuf), NULL);
+    err = ::WSAGetLastError();
+    // TODO: Get string representation of error.
+    // char errbuf[300];  // TODO: Needs to be LPWSTR
+    // FormatMessage(FORMAT_MESSAGE_FROM_SYSTEM, NULL, err, 0, errbuf, sizeof(errbuf), NULL);
+    // fprintf(stderr, "UDPSocket error: %s\n", errbuf);
 #else
-    int sv_err = errno;
-    const char* errbuf = strerror(sv_err);
+    err = errno;
+    const char* errbuf = strerror(err);
+    fprintf(stderr, "UDPSocket error: %s\n", errbuf);
 #endif
-    fprintf(stderr, "UDP socket error: %s\n", errbuf);
+    TRACE("UDPSocket error number was %i\n", err);
+
     m_TCPconnected = false;
     shutdown(inst_sock, SD_BOTH); // shutdown communication
 #ifdef WIN32

--- a/CentralCommon/BmiVersion.h
+++ b/CentralCommon/BmiVersion.h
@@ -25,7 +25,7 @@
 
 #define BMI_VERSION_MAJOR    7
 #define BMI_VERSION_MINOR    6
-#define BMI_VERSION_RELEASE  0
+#define BMI_VERSION_RELEASE  1
 #define BMI_VERSION_BETA     0
 
 // Take care of the leading zero

--- a/CentralCommon/BmiVersion.h
+++ b/CentralCommon/BmiVersion.h
@@ -3,7 +3,7 @@
 // (c) Copyright 2010 - 2023 Blackrock Microsystems
 //
 // $Workfile: BmiVersion.h $
-// $Archive: /common/BmiVersion.h $
+// $Archive: /CentralCommon/BmiVersion.h $
 // $Revision: 1 $
 // $Date: 7/19/10 9:52a $
 // $Author: Ehsan $
@@ -24,9 +24,9 @@
 #define STRINGIFY(s) STR(s)
 
 #define BMI_VERSION_MAJOR    7
-#define BMI_VERSION_MINOR    5
-#define BMI_VERSION_RELEASE  1
-#define BMI_VERSION_BETA     3
+#define BMI_VERSION_MINOR    6
+#define BMI_VERSION_RELEASE  0
+#define BMI_VERSION_BETA     0
 
 // Take care of the leading zero
 #if BMI_VERSION_MINOR < 10

--- a/cbhwlib/cbhwlib.h
+++ b/cbhwlib/cbhwlib.h
@@ -17,6 +17,7 @@
 #include "pstdint.h"
 #else
 #include "stdint.h"
+#include <stddef.h>  // For NULL on some compilers
 #endif
 
 #pragma pack(push, 1)

--- a/cbsdk/cbsdk.cpp
+++ b/cbsdk/cbsdk.cpp
@@ -844,8 +844,12 @@ cbSdkResult SdkApp::SdkOpen(uint32_t nInstance, cbSdkConnectionType conType, cbS
     else
         return CBSDKRESULT_NOTIMPLEMENTED;
 
-    // Wait for (dis)connection to happen
+    // Wait for (dis)connection to happen (wait forever if debug)
+#ifndef NDEBUG
+    bool bWait = m_connectWait.wait(&m_connectLock);
+#else
     bool bWait = m_connectWait.wait(&m_connectLock, 15000);
+#endif
     m_connectLock.unlock();
 
     if (!bWait)

--- a/cerebus/__init__.py
+++ b/cerebus/__init__.py
@@ -1,1 +1,1 @@
-__version__ = 0.2
+__version__ = 0.3


### PR DESCRIPTION
This fixes a bug in Linux where the `setsockopt` calls were unhappy with the values they were passed as a result of casting bools to the expected argument types. Switching these to ints works well.
Not yet tested on non-Linux platforms...