### PR TITLE
Backport protocol 3.11

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,6 +50,7 @@ option(BUILD_CBMEX "Build Matlab wrapper" ON)
 option(BUILD_CBOCT "Build Octave wrapper" ON)
 option(BUILD_TEST "Build tests" ON)
 option(BUILD_HDF5 "Build HDF5" ON)
+option(CBPROTO_311 "Build for protocol 3.11" OFF)
 
 ##########################################################################################
 # Define target names
@@ -73,6 +74,9 @@ ENDIF()
 SET(CMAKE_DEBUG_POSTFIX "d" CACHE STRING "Add a postfix, usually d on windows")
 
 # -?
+if(${CBPROTO_311})
+    add_compile_definitions(CBPROTO_311)
+endif()
 ADD_DEFINITIONS( -DCBSDK_EXPORTS )
 IF( WIN32 )
     # From cbhwlib/cbmex.vcproj: PreprocessorDefinitions="WIN32;_WINDOWS;NO_AFX;WINVER=0x0501;CBSDK_EXPORTS;QT_APP"

--- a/cbhwlib/CCFUtils.cpp
+++ b/cbhwlib/CCFUtils.cpp
@@ -115,7 +115,11 @@ ccfResult CCFUtils::SendCCF()
             switch (data.isChan[i].chancaps)
             {
             case cbCHAN_EXISTS | cbCHAN_CONNECTED | cbCHAN_ISOLATED | cbCHAN_AINP:  // FE channels
-                nChannelNumber = cbGetExpandedChannelNumber(data.isChan[i].cbpkt_header.instrument + 1, data.isChan[i].chan);
+#ifdef CBPROTO_311
+                    nChannelNumber = cbGetExpandedChannelNumber(1, data.isChan[i].chan);
+#else
+                    nChannelNumber = cbGetExpandedChannelNumber(data.isChan[i].cbpkt_header.instrument + 1, data.isChan[i].chan);
+#endif
                 break;
             case cbCHAN_EXISTS | cbCHAN_CONNECTED | cbCHAN_AINP:  // Analog input channels
                 nChannelNumber = GetAIAnalogInChanNumber(nAinChan++);
@@ -144,7 +148,9 @@ ccfResult CCFUtils::SendCCF()
             {
                 data.isChan[i].chan = nChannelNumber;
                 data.isChan[i].cbpkt_header.type = cbPKTTYPE_CHANSET;
+#ifndef CBPROTO_311
                 data.isChan[i].cbpkt_header.instrument = data.isChan[i].proc - 1;   // send to the correct instrument
+#endif
                 cbSendPacket(&data.isChan[i], m_nInstance);
             }
         }
@@ -195,7 +201,9 @@ ccfResult CCFUtils::SendCCF()
             if (data.isWaveform[nChan][nTrigger].chan)
             {
                 data.isWaveform[nChan][nTrigger].chan = GetAnalogOutChanNumber(nChan + 1);
+#ifndef CBPROTO_311
                 data.isWaveform[nChan][nTrigger].cbpkt_header.instrument = cbGetChanInstrument(data.isWaveform[nChan][nTrigger].chan);
+#endif
                 data.isWaveform[nChan][nTrigger].cbpkt_header.type = cbPKTTYPE_WAVEFORMSET;
                 cbSendPacket(&data.isWaveform[nChan][nTrigger], m_nInstance);
             }
@@ -208,7 +216,12 @@ ccfResult CCFUtils::SendCCF()
         memset(szNTrodeLabel, 0, sizeof(szNTrodeLabel));
         cbGetNTrodeInfo(nNTrode + 1, szNTrodeLabel, NULL, NULL, NULL, NULL);
 
-        if ((0 != strlen(szNTrodeLabel)) && (cbGetNTrodeInstrument(nNTrode + 1) == data.isNTrodeInfo->cbpkt_header.instrument + 1))
+        if (
+                (0 != strlen(szNTrodeLabel))
+#ifndef CBPROTO_311
+            && (cbGetNTrodeInstrument(nNTrode + 1) == data.isNTrodeInfo->cbpkt_header.instrument + 1)
+#endif
+        )
         {
             if (data.isNTrodeInfo[nNTrode].ntrode)
             {

--- a/cbhwlib/CCFUtilsBinary.cpp
+++ b/cbhwlib/CCFUtilsBinary.cpp
@@ -289,8 +289,12 @@ ccfResult CCFUtilsBinary::ReadCCFData_cb2003_10_a(FILE * hFile)
             isChan.dinpopts    = isChanFile.dinpopts;
             isChan.aoutopts    = isChanFile.aoutopts;
             isChan.eopchar     = isChanFile.eopchar;
-            isChan.moninst     = isChanFile.moninst;
-            isChan.monchan     = isChanFile.monchan;
+#ifdef CBPROTO_311
+            isChan.monsource   = isChanFile.monsource;
+#else
+            isChan.moninst     = (uint16_t)(isChanFile.monsource&0xffff);
+            isChan.monchan     = (uint16_t)((isChanFile.monsource>>16)&0xffff);
+#endif
             isChan.outvalue    = isChanFile.outvalue;
             isChan.ainpopts    = isChanFile.lncmode;
             isChan.lncrate     = isChanFile.lncrate;
@@ -381,8 +385,12 @@ ccfResult CCFUtilsBinary::ReadCCFData_cb2005_25(FILE * hFile)
             isChan.dinpopts    = isChanFile.dinpopts;
             isChan.aoutopts    = isChanFile.aoutopts;
             isChan.eopchar     = isChanFile.eopchar;
-            isChan.moninst     = isChanFile.moninst;
-            isChan.monchan     = isChanFile.monchan;
+#ifdef CBPROTO_311
+            isChan.monsource   = isChanFile.monsource;
+#else
+            isChan.moninst     = (uint16_t)(isChanFile.monsource&0xffff);
+            isChan.monchan     = (uint16_t)((isChanFile.monsource>>16)&0xffff);
+#endif
             isChan.outvalue    = isChanFile.outvalue;
             isChan.ainpopts    = isChanFile.lncmode;
             isChan.lncrate     = isChanFile.lncrate;
@@ -461,8 +469,12 @@ ccfResult CCFUtilsBinary::ReadCCFData_cb2005_30(FILE * hFile)
             isChan.dinpopts    = isChanFile.dinpopts;
             isChan.aoutopts    = isChanFile.aoutopts;
             isChan.eopchar     = isChanFile.eopchar;
-            isChan.moninst     = isChanFile.moninst;
-            isChan.monchan     = isChanFile.monchan;
+#ifdef CBPROTO_311
+            isChan.monsource   = isChanFile.monsource;
+#else
+            isChan.moninst     = (uint16_t)(isChanFile.monsource&0xffff);
+            isChan.monchan     = (uint16_t)((isChanFile.monsource>>16)&0xffff);
+#endif
             isChan.outvalue    = isChanFile.outvalue;
             isChan.ainpopts    = isChanFile.lncmode;
             isChan.lncrate     = isChanFile.lncrate;
@@ -541,8 +553,12 @@ ccfResult CCFUtilsBinary::ReadCCFData_cb2005_31(FILE * hFile)
             isChan.dinpopts    = isChanFile.dinpopts;
             isChan.aoutopts    = isChanFile.aoutopts;
             isChan.eopchar     = isChanFile.eopchar;
-            isChan.moninst     = isChanFile.moninst;
-            isChan.monchan     = isChanFile.monchan;
+#ifdef CBPROTO_311
+            isChan.monsource   = isChanFile.monsource;
+#else
+            isChan.moninst     = (uint16_t)(isChanFile.monsource&0xffff);
+            isChan.monchan     = (uint16_t)((isChanFile.monsource>>16)&0xffff);
+#endif
             isChan.outvalue    = isChanFile.outvalue;
             isChan.ainpopts    = isChanFile.lncmode;
             isChan.lncrate     = isChanFile.lncrate;
@@ -638,8 +654,12 @@ ccfResult CCFUtilsBinary::ReadCCFData_cb2005_34(FILE * hFile)
             isChan.dinpopts    = isChanFile.dinpopts;
             isChan.aoutopts    = isChanFile.aoutopts;
             isChan.eopchar     = isChanFile.eopchar;
-            isChan.moninst     = isChanFile.moninst;
-            isChan.monchan     = isChanFile.monchan;
+#ifdef CBPROTO_311
+            isChan.monsource   = isChanFile.monsource;
+#else
+            isChan.moninst     = (uint16_t)(isChanFile.monsource&0xffff);
+            isChan.monchan     = (uint16_t)((isChanFile.monsource>>16)&0xffff);
+#endif
             isChan.outvalue    = isChanFile.outvalue;
             isChan.ainpopts    = isChanFile.lncmode;
             isChan.lncrate     = isChanFile.lncrate;
@@ -734,8 +754,12 @@ ccfResult CCFUtilsBinary::ReadCCFData_cb2005_35(FILE * hFile)
             isChan.dinpopts    = isChanFile.dinpopts;
             isChan.aoutopts    = isChanFile.aoutopts;
             isChan.eopchar     = isChanFile.eopchar;
-            isChan.moninst     = isChanFile.moninst;
-            isChan.monchan     = isChanFile.monchan;
+#ifdef CBPROTO_311
+            isChan.monsource   = isChanFile.monsource;
+#else
+            isChan.moninst     = (uint16_t)(isChanFile.monsource&0xffff);
+            isChan.monchan     = (uint16_t)((isChanFile.monsource>>16)&0xffff);
+#endif
             isChan.outvalue    = isChanFile.outvalue;
             isChan.ainpopts    = isChanFile.lncmode;
             isChan.lncrate     = isChanFile.lncrate;
@@ -830,8 +854,12 @@ ccfResult CCFUtilsBinary::ReadCCFData_cb2005_36(FILE * hFile)
             isChan.dinpopts    = isChanFile.dinpopts;
             isChan.aoutopts    = isChanFile.aoutopts;
             isChan.eopchar     = isChanFile.eopchar;
-            isChan.moninst     = isChanFile.moninst;
-            isChan.monchan     = isChanFile.monchan;
+#ifdef CBPROTO_311
+            isChan.monsource   = isChanFile.monsource;
+#else
+            isChan.moninst     = (uint16_t)(isChanFile.monsource&0xffff);
+            isChan.monchan     = (uint16_t)((isChanFile.monsource>>16)&0xffff);
+#endif
             isChan.outvalue    = isChanFile.outvalue;
             isChan.ainpopts    = isChanFile.ainpopts;
             isChan.lncrate     = isChanFile.lncrate;
@@ -917,8 +945,12 @@ ccfResult CCFUtilsBinary::ReadCCFData_cb2005_37(FILE * hFile)
             isChan.dinpopts    = isChanFile.dinpopts;
             isChan.aoutopts    = isChanFile.aoutopts;
             isChan.eopchar     = isChanFile.eopchar;
-            isChan.moninst     = isChanFile.moninst;
-            isChan.monchan     = isChanFile.monchan;
+#ifdef CBPROTO_311
+            isChan.monsource   = isChanFile.monsource;
+#else
+            isChan.moninst     = (uint16_t)(isChanFile.monsource&0xffff);
+            isChan.monchan     = (uint16_t)((isChanFile.monsource>>16)&0xffff);
+#endif
             isChan.outvalue    = isChanFile.outvalue;
             isChan.ainpopts    = isChanFile.ainpopts;
             isChan.lncrate     = isChanFile.lncrate;

--- a/cbhwlib/CCFUtilsBinary.h
+++ b/cbhwlib/CCFUtilsBinary.h
@@ -145,8 +145,7 @@ typedef struct {
     uint32_t     dinpopts;    // digital input options (composed of cbDINP_* flags)
     uint32_t     aoutopts;    // analog output options
     uint32_t     eopchar;     // digital input capablities (given by cbDINP_* flags)
-    uint16_t     moninst;     // instrument of channel to monitor
-    uint16_t     monchan;     // channel to monitor
+    uint32_t     monsource;   // Address of channel to monitor, or (moninst | monchan << 16)
     int32_t      outvalue;    // output value
     uint32_t     lncmode;     // line noise cancellation filter mode
     uint32_t     lncrate;     // line noise cancellation filter adaptation rate
@@ -191,8 +190,7 @@ typedef struct {
     uint32_t     dinpopts;    // digital input options (composed of cbDINP_* flags)
     uint32_t     aoutopts;    // analog output options
     uint32_t     eopchar;     // digital input capablities (given by cbDINP_* flags)
-    uint16_t     moninst;     // instrument of channel to monitor
-    uint16_t     monchan;     // channel to monitor
+    uint32_t     monsource;   // Address of channel to monitor, or (moninst | monchan << 16)
     int32_t      outvalue;    // output value
     uint32_t     lncmode;     // line noise cancellation filter mode
     uint32_t     lncrate;     // line noise cancellation filter adaptation rate
@@ -236,8 +234,7 @@ typedef struct {
     uint32_t          dinpopts;    // digital input options (composed of cbDINP_* flags)
     uint32_t          aoutopts;    // analog output options
     uint32_t          eopchar;     // digital input capablities (given by cbDINP_* flags)
-    uint16_t          moninst;     // instrument of channel to monitor
-    uint16_t          monchan;     // channel to monitor
+    uint32_t          monsource;   // Address of channel to monitor, or (moninst | monchan << 16)
     int32_t           outvalue;    // output value
     uint32_t          lncmode;     // line noise cancellation filter mode
     uint32_t          lncrate;     // line noise cancellation filter adaptation rate
@@ -282,8 +279,7 @@ typedef struct {
     uint32_t              dinpopts;    // digital input options (composed of cbDINP_* flags)
     uint32_t              aoutopts;    // analog output options
     uint32_t              eopchar;     // digital input capablities (given by cbDINP_* flags)
-    uint16_t              moninst;     // instrument of channel to monitor
-    uint16_t              monchan;     // channel to monitor
+    uint32_t              monsource;   // Address of channel to monitor, or (moninst | monchan << 16)
     int32_t               outvalue;    // output value
     uint32_t              lncmode;     // line noise cancellation filter mode
     uint32_t              lncrate;     // line noise cancellation filter adaptation rate
@@ -329,8 +325,7 @@ typedef struct {
     uint32_t              dinpopts;    // digital input options (composed of cbDINP_* flags)
     uint32_t              aoutopts;    // analog output options
     uint32_t              eopchar;     // digital input capablities (given by cbDINP_* flags)
-    uint16_t              moninst;     // instrument of channel to monitor
-    uint16_t              monchan;     // channel to monitor
+    uint32_t              monsource;   // Address of channel to monitor, or (moninst | monchan << 16)
     int32_t               outvalue;    // output value
     uint32_t              lncmode;     // line noise cancellation filter mode
     uint32_t              lncrate;     // line noise cancellation filter adaptation rate
@@ -378,8 +373,7 @@ typedef struct {
     uint32_t              eopchar;        // digital input capablities (given by cbDINP_* flags)
     union {
         struct {
-            uint16_t              moninst;     // instrument of channel to monitor
-            uint16_t              monchan;     // channel to monitor
+            uint32_t              monsource;   // Address of channel to monitor, or (moninst | monchan << 16)
             int32_t               outvalue;       // output value
         };
         struct {
@@ -436,8 +430,7 @@ typedef struct {
     uint32_t              eopchar;        // digital input capablities (given by cbDINP_* flags)
     union {
         struct {
-            uint16_t              moninst;     // instrument of channel to monitor
-            uint16_t              monchan;     // channel to monitor
+            uint32_t              monsource;   // Address of channel to monitor, or (moninst | monchan << 16)
             int32_t               outvalue;       // output value
         };
         struct {
@@ -496,8 +489,7 @@ typedef struct {
     uint32_t              eopchar;        // digital input capablities (given by cbDINP_* flags)
     union {
         struct {
-            uint16_t              moninst;     // instrument of channel to monitor
-            uint16_t              monchan;     // channel to monitor
+            uint32_t              monsource;   // Address of channel to monitor, or (moninst | monchan << 16)
             int32_t               outvalue;       // output value
         };
         struct {
@@ -558,7 +550,7 @@ typedef struct {
     uint32_t     eopchar;        // digital input capablities (given by cbDINP_* flags)
     union {
         struct {
-            uint32_t              monsource;      // address of channel to monitor
+            uint32_t              monsource;      // address of channel to monitor, (moninst | monchan << 16)
             int32_t               outvalue;       // output value
         };
         struct {

--- a/cbhwlib/InstNetwork.cpp
+++ b/cbhwlib/InstNetwork.cpp
@@ -581,7 +581,9 @@ void InstNetwork::timerEvent(QTimerEvent * /*event*/)
             pktgeneric.cbpkt_header.chid = 0x8000;
             pktgeneric.cbpkt_header.type = cbPKTTYPE_REQCONFIGALL;
             pktgeneric.cbpkt_header.dlen = 0;
+#ifndef CBPROTO_311
             pktgeneric.cbpkt_header.instrument = 0;
+#endif
             cbSendPacket(&pktgeneric, m_nInstance);
         }
         // at 2.0 seconds, if not already running, do soft reset, which will lead to running state.

--- a/cbhwlib/cbHwlibHi.cpp
+++ b/cbhwlib/cbHwlibHi.cpp
@@ -1180,6 +1180,7 @@ uint32_t cbGetNumActiveInstruments()
     return nNumActiveInstruments;
 }
 
+
 NSP_STATUS cbGetNspStatus(uint32_t nInstrument)
 {
     if (nInstrument > cbMAXPROCS)
@@ -1187,12 +1188,14 @@ NSP_STATUS cbGetNspStatus(uint32_t nInstrument)
     return cb_pc_status_buffer_ptr[0]->cbGetNspStatus(nInstrument - 1);
 }
 
+#ifndef CBPROTO_311
 void cbSetNspStatus(uint32_t nInstrument, NSP_STATUS nStatus)
 {
     ASSERT(nInstrument - 1 < cbMAXPROCS);
     if (nInstrument - 1 < cbMAXPROCS)
         cb_pc_status_buffer_ptr[0]->cbSetNspStatus(nInstrument - 1, nStatus);
 }
+#endif
 
 uint32_t cbGetExpandedChannelNumber(uint32_t nInstrument, uint32_t nChannel)
 {

--- a/cbhwlib/cbHwlibHi.cpp
+++ b/cbhwlib/cbHwlibHi.cpp
@@ -955,9 +955,10 @@ uint32_t cbGetNTrodeInstrument(uint32_t nNTrode, uint32_t nInstance)
 {
     uint32_t nInstrument = cbNSP1;    // add to chan for instruments > 0
     uint32_t nIdx = cb_library_index[nInstance];
-
+#ifndef CBPROTO_311
     if (cb_cfg_buffer_ptr[nIdx]->isNTrodeInfo[nNTrode - 1].cbpkt_header.instrument < cbMAXPROCS)
         nInstrument = cb_cfg_buffer_ptr[nIdx]->isNTrodeInfo[nNTrode - 1].cbpkt_header.instrument + 1;
+#endif
     ASSERT(nInstrument - 1 < cbMAXPROCS);
 
     return nInstrument;
@@ -1226,8 +1227,10 @@ uint32_t cbGetChanInstrument(uint32_t nChannel, uint32_t nInstance)
     if ((nChannel - 1) >= cbMAXCHANS)
         return 0;
 
+#ifndef CBPROTO_311
     if (cb_cfg_buffer_ptr[nIdx]->chaninfo[nChannel - 1].cbpkt_header.instrument < cbMAXPROCS)
         nInstrument = cb_cfg_buffer_ptr[nIdx]->chaninfo[nChannel - 1].cbpkt_header.instrument + 1;
+#endif
     ASSERT(nInstrument - 1 < cbMAXPROCS);
 
     return nInstrument;

--- a/cbhwlib/cbHwlibHi.h
+++ b/cbhwlib/cbHwlibHi.h
@@ -112,7 +112,9 @@ uint32_t GetDigoutChanNumber(uint32_t nOrdinal, uint32_t nInstance = 0);
 
 uint32_t cbGetNumActiveInstruments();
 NSP_STATUS cbGetNspStatus(uint32_t nInstrument);
+#ifndef CBPROTO_311
 void cbSetNspStatus(uint32_t nInstrument, NSP_STATUS nStatus);
+#endif
 uint32_t cbGetExpandedChannelNumber(uint32_t nInstrument, uint32_t nChannel);
 uint32_t cbGetChanInstrument(uint32_t nChannel, uint32_t nInstance = 0);
 uint32_t cbGetInstrumentLocalChannelNumber(uint32_t nChan);

--- a/cbhwlib/cbhwlib.cpp
+++ b/cbhwlib/cbhwlib.cpp
@@ -1041,8 +1041,10 @@ cbRESULT cbSetComment(uint8_t charset, uint32_t rgba, PROCTIME time, const char*
     pktComment.cbpkt_header.chid           = 0x8000;
     pktComment.cbpkt_header.type           = cbPKTTYPE_COMMENTSET;
     pktComment.info.charset   = charset;
+#ifndef CBPROTO_311
     pktComment.rgba = rgba;
     pktComment.timeStarted = time;
+#endif
     uint32_t nLen = 0;
     if (comment)
         strncpy(pktComment.comment, comment, cbMAX_COMMENT);
@@ -1055,7 +1057,9 @@ cbRESULT cbSetComment(uint8_t charset, uint32_t rgba, PROCTIME time, const char*
     {
         if ((cbRESULT_OK == bRes) && (NSP_FOUND == cbGetNspStatus(nProc)))
         {
+#ifndef CBPROTO_311
             pktComment.cbpkt_header.instrument = nProc - 1;
+#endif
             bRes = cbSendPacket(&pktComment, nInstance);
         }
     }
@@ -1093,7 +1097,9 @@ cbRESULT cbSetLncParameters(uint32_t proc, uint32_t nLncFreq, uint32_t nLncRefCh
     pktLnc.cbpkt_header.chid           = 0x8000;
     pktLnc.cbpkt_header.type           = cbPKTTYPE_LNCSET;
     pktLnc.cbpkt_header.dlen           = cbPKTDLEN_LNC;
+#ifndef CBPROTO_311
     pktLnc.cbpkt_header.instrument     = proc - 1;
+#endif
     pktLnc.lncFreq        = nLncFreq;
     pktLnc.lncRefChan     = nLncRefChan;
     pktLnc.lncGlobalMode  = nLncGMode;
@@ -1139,7 +1145,9 @@ cbRESULT cbSetNplay(const char *fname, float speed, uint32_t mode, PROCTIME val,
     pktNPlay.cbpkt_header.chid           = 0x8000;
     pktNPlay.cbpkt_header.type           = cbPKTTYPE_NPLAYSET;
     pktNPlay.cbpkt_header.dlen           = cbPKTDLEN_NPLAY;
+#ifndef CBPROTO_311
     pktNPlay.cbpkt_header.instrument     = cbNSP1 - 1;
+#endif
     pktNPlay.speed          = speed;
     pktNPlay.mode           = mode;
     pktNPlay.flags          = cbNPLAY_FLAG_NONE; // No flags here
@@ -1230,7 +1238,9 @@ cbRESULT cbSetVideoSource(const char *name, float fps, uint32_t vs, uint32_t nIn
     {
         if ((cbRESULT_OK == cbRes) && (NSP_FOUND == cbGetNspStatus(nProc)))
         {
+#ifndef CBPROTO_311
             pktNm.cbpkt_header.instrument = nProc - 1;
+#endif
             cbRes = cbSendPacket(&pktNm, nInstance);
         }
     }
@@ -1266,7 +1276,9 @@ cbRESULT cbSetTrackObj(const char *name, uint16_t type, uint16_t pointCount, uin
     {
         if ((cbRESULT_OK == cbRes) && (NSP_FOUND == cbGetNspStatus(nProc)))
         {
+#ifndef CBPROTO_311
             pktNm.cbpkt_header.instrument = nProc - 1;
+#endif
             cbRes = cbSendPacket(&pktNm, nInstance);
         }
     }
@@ -1313,7 +1325,9 @@ cbRESULT cbSetSpikeLength(uint32_t length, uint32_t pretrig, uint32_t nInstance)
     {
         if ((cbRESULT_OK == bRes) && (NSP_FOUND == cbGetNspStatus(nProc)))
         {
+#ifndef CBPROTO_311
             sysinfo.cbpkt_header.instrument = nProc - 1;
+#endif
             bRes = cbSendPacket(&sysinfo, nInstance);  // Enter the packet into the XMT buffer queue
         }
     }
@@ -1550,7 +1564,9 @@ cbRESULT cbSetChanLabel(uint32_t chan, const char *label, uint32_t userflags, in
     chaninfo.cbpkt_header.chid      = 0x8000;
     chaninfo.cbpkt_header.type      = cbPKTTYPE_CHANSETLABEL;
     chaninfo.cbpkt_header.dlen      = cbPKTDLEN_CHANINFO;
+#ifndef CBPROTO_311
     chaninfo.cbpkt_header.instrument = cb_cfg_buffer_ptr[nIdx]->chaninfo[chan - 1].cbpkt_header.instrument;
+#endif
     chaninfo.chan                   = cb_cfg_buffer_ptr[nIdx]->chaninfo[chan - 1].chan;
     memcpy(chaninfo.label, label, cbLEN_STR_LABEL);
     chaninfo.userflags = userflags;
@@ -1603,7 +1619,9 @@ cbRESULT cbSetChanUnitMapping(uint32_t chan, cbMANUALUNITMAPPING *unitmapping, u
     chaninfo.cbpkt_header.chid      = 0x8000;
     chaninfo.cbpkt_header.type      = cbPKTTYPE_CHANSETUNITOVERRIDES;
     chaninfo.cbpkt_header.dlen      = cbPKTDLEN_CHANINFO;
+#ifndef CBPROTO_311
     chaninfo.cbpkt_header.instrument = cb_cfg_buffer_ptr[nIdx]->chaninfo[chan - 1].cbpkt_header.instrument;
+#endif
     chaninfo.chan                    = cb_cfg_buffer_ptr[nIdx]->chaninfo[chan - 1].chan;
     if (unitmapping)
         memcpy(&chaninfo.unitmapping, unitmapping, cbMAXUNITS * sizeof(cbMANUALUNITMAPPING));
@@ -1648,7 +1666,9 @@ cbRESULT cbSetChanNTrodeGroup( uint32_t chan, const uint32_t NTrodeGroup, uint32
     chaninfo.cbpkt_header.chid      = 0x8000;
     chaninfo.cbpkt_header.type      = cbPKTTYPE_CHANSETNTRODEGROUP;
     chaninfo.cbpkt_header.dlen      = cbPKTDLEN_CHANINFOSHORT;
+#ifndef CBPROTO_311
     chaninfo.cbpkt_header.instrument = cb_cfg_buffer_ptr[nIdx]->chaninfo[chan - 1].cbpkt_header.instrument;
+#endif
     chaninfo.chan                    = cb_cfg_buffer_ptr[nIdx]->chaninfo[chan - 1].chan;
     if (0 == NTrodeGroup)
         chaninfo.spkgroup = 0;
@@ -1698,7 +1718,9 @@ cbRESULT cbSetChanAmplitudeReject(uint32_t chan, const cbAMPLITUDEREJECT Amplitu
     chaninfo.cbpkt_header.chid      = 0x8000;
     chaninfo.cbpkt_header.type      = cbPKTTYPE_CHANSETREJECTAMPLITUDE;
     chaninfo.cbpkt_header.dlen      = cbPKTDLEN_CHANINFOSHORT;
+#ifndef CBPROTO_311
     chaninfo.cbpkt_header.instrument = cb_cfg_buffer_ptr[nIdx]->chaninfo[chan - 1].cbpkt_header.instrument;
+#endif
     chaninfo.chan      = cb_cfg_buffer_ptr[nIdx]->chaninfo[chan - 1].chan;
     chaninfo.spkopts   = cb_cfg_buffer_ptr[nIdx]->chaninfo[chan - 1].spkopts & ~cbAINPSPK_REJAMPL;
     chaninfo.spkopts  |= AmplitudeReject.bEnabled ? cbAINPSPK_REJAMPL : 0;
@@ -1770,7 +1792,9 @@ cbRESULT cbSetChanAutoThreshold( uint32_t chan, const uint32_t bEnabled, uint32_
     chaninfo.cbpkt_header.chid      = 0x8000;
     chaninfo.cbpkt_header.type      = cbPKTTYPE_CHANSETAUTOTHRESHOLD;
     chaninfo.cbpkt_header.dlen      = cbPKTDLEN_CHANINFOSHORT;
+#ifndef CBPROTO_311
     chaninfo.cbpkt_header.instrument = cb_cfg_buffer_ptr[nIdx]->chaninfo[chan - 1].cbpkt_header.instrument;
+#endif
     chaninfo.chan      = cb_cfg_buffer_ptr[nIdx]->chaninfo[chan - 1].chan;
     chaninfo.spkopts   = cb_cfg_buffer_ptr[nIdx]->chaninfo[chan - 1].spkopts & ~cbAINPSPK_THRAUTO;
     chaninfo.spkopts  |= bEnabled ? cbAINPSPK_THRAUTO : 0;
@@ -1817,7 +1841,9 @@ cbRESULT cbSetNTrodeInfo( const uint32_t ntrode, const char *label, cbMANUALUNIT
     ntrodeinfo.cbpkt_header.chid      = 0x8000;
     ntrodeinfo.cbpkt_header.type      = cbPKTTYPE_SETNTRODEINFO;
     ntrodeinfo.cbpkt_header.dlen      = cbPKTDLEN_NTRODEINFO;
+#ifndef CBPROTO_311
     ntrodeinfo.cbpkt_header.instrument = cbGetNTrodeInstrument(ntrode) - 1;
+#endif
     ntrodeinfo.ntrode = cb_cfg_buffer_ptr[nIdx]->isNTrodeInfo[ntrode - 1].ntrode;
     ntrodeinfo.fs        = fs;
     if (label) memcpy(ntrodeinfo.label, label, sizeof(ntrodeinfo.label));
@@ -1850,7 +1876,9 @@ cbRESULT cbSetNTrodeLabel(const uint32_t ntrode, const char* label, uint32_t nIn
     ntrodeinfo.cbpkt_header.chid = 0x8000;
     ntrodeinfo.cbpkt_header.type = cbPKTTYPE_SETNTRODEINFO;
     ntrodeinfo.cbpkt_header.dlen = cbPKTDLEN_NTRODEINFO;
+#ifndef CBPROTO_311
     ntrodeinfo.cbpkt_header.instrument = cbGetNTrodeInstrument(ntrode) - 1;
+#endif
     ntrodeinfo.ntrode = cb_cfg_buffer_ptr[nIdx]->isNTrodeInfo[ntrode - 1].ntrode;
     ntrodeinfo.fs = cb_cfg_buffer_ptr[nIdx]->isNTrodeInfo[ntrode - 1].fs;
     if (label) memcpy(ntrodeinfo.label, label, sizeof(ntrodeinfo.label));
@@ -1922,7 +1950,9 @@ cbRESULT cbSetDinpOptions(uint32_t chan, uint32_t options, uint32_t eopchar, uin
     chaninfo.cbpkt_header.chid      = 0x8000;
     chaninfo.cbpkt_header.type      = cbPKTTYPE_CHANSETDINP;
     chaninfo.cbpkt_header.dlen      = cbPKTDLEN_CHANINFO;
+#ifndef CBPROTO_311
     chaninfo.cbpkt_header.instrument = cb_cfg_buffer_ptr[nIdx]->chaninfo[chan - 1].cbpkt_header.instrument;
+#endif
     chaninfo.chan = cb_cfg_buffer_ptr[nIdx]->chaninfo[chan - 1].chan;
     chaninfo.dinpopts  = options;     // digital input options (composed of nmDINP_* flags)
     chaninfo.eopchar   = eopchar;     // digital input capablities (given by nmDINP_* flags)
@@ -1972,10 +2002,21 @@ cbRESULT cbGetDoutOptions(uint32_t chan, uint32_t *options, uint32_t *monchan, u
         if ((cbDOUT_FREQUENCY & cb_cfg_buffer_ptr[nIdx]->chaninfo[chan - 1].doutopts) ||
             (cbDOUT_TRIGGERED & cb_cfg_buffer_ptr[nIdx]->chaninfo[chan - 1].doutopts))
         {
-            *monchan = cb_cfg_buffer_ptr[nIdx]->chaninfo[chan - 1].moninst | (cb_cfg_buffer_ptr[nIdx]->chaninfo[chan - 1].monchan << 16);
+#ifdef CBPROTO_311
+            *monchan = cb_cfg_buffer_ptr[nIdx]->chaninfo[chan - 1].monsource;
         }
-        else
-            *monchan        = cbGetExpandedChannelNumber(cb_cfg_buffer_ptr[nIdx]->chaninfo[chan - 1].moninst + 1, cb_cfg_buffer_ptr[nIdx]->chaninfo[chan - 1].monchan);
+        else {
+            *monchan = cbGetExpandedChannelNumber(cb_cfg_buffer_ptr[nIdx]->chaninfo[chan - 1].monsource&0xfff,
+                                                  (cb_cfg_buffer_ptr[nIdx]->chaninfo[chan - 1].monsource >> 16)&0xfff);
+        }
+#else
+            *monchan = cb_cfg_buffer_ptr[nIdx]->chaninfo[chan - 1].moninst | (cb_cfg_buffer_ptr[nIdx]->chaninfo[chan - 1].monchan << 16);
+            }
+        else {
+            *monchan = cbGetExpandedChannelNumber(cb_cfg_buffer_ptr[nIdx]->chaninfo[chan - 1].moninst + 1,
+                                                  cb_cfg_buffer_ptr[nIdx]->chaninfo[chan - 1].monchan);
+        }
+#endif
     }
     if (value)			*value			= cb_cfg_buffer_ptr[nIdx]->chaninfo[chan - 1].outvalue;
     if (triggertype)    *triggertype	= cb_cfg_buffer_ptr[nIdx]->chaninfo[chan - 1].trigtype;
@@ -1992,9 +2033,6 @@ cbRESULT cbSetDoutOptions(uint32_t chan, uint32_t options, uint32_t monchan, uin
 {
     cbRESULT nResult = cbRESULT_OK;
     uint32_t nIdx = cb_library_index[nInstance];
-    uint32_t nMonChan = monchan & 0xFFFF;
-    uint32_t nMonSamples = monchan & 0xFFFF0000;
-
     // Test for prior library initialization
     if (!cb_library_initialized[nIdx]) return cbRESULT_NOLIBRARY;
 
@@ -2009,20 +2047,30 @@ cbRESULT cbSetDoutOptions(uint32_t chan, uint32_t options, uint32_t monchan, uin
     chaninfo.cbpkt_header.chid      = 0x8000;
     chaninfo.cbpkt_header.type      = cbPKTTYPE_CHANSETDOUT;
     chaninfo.cbpkt_header.dlen      = cbPKTDLEN_CHANINFO;
+#ifndef CBPROTO_311
     chaninfo.cbpkt_header.instrument = cb_cfg_buffer_ptr[nIdx]->chaninfo[chan - 1].cbpkt_header.instrument;
+#endif
     chaninfo.chan = cb_cfg_buffer_ptr[nIdx]->chaninfo[chan - 1].chan;
     chaninfo.doutopts  = options;
     if ((cbDOUT_FREQUENCY & options) || (cbDOUT_TRIGGERED & options))
     {
+#ifdef CBPROTO_311
+        chaninfo.monsource = monchan;
+#else
         chaninfo.moninst = monchan & 0xFFFF;
-        chaninfo.monchan = monchan >> 16;
+        chaninfo.monchan = (monchan >> 16) & 0xFFFF;
+#endif
     }
     else
     {
         if (0 != monchan)
         {
+#ifdef CBPROTO_311
+            chaninfo.monsource = cbGetInstrumentLocalChannelNumber(monchan);
+#else
             chaninfo.moninst = cbGetChanInstrument(monchan) - 1;
             chaninfo.monchan = cbGetInstrumentLocalChannelNumber(monchan);
+#endif
         }
     }
     chaninfo.outvalue  = value;
@@ -2034,7 +2082,9 @@ cbRESULT cbSetDoutOptions(uint32_t chan, uint32_t options, uint32_t monchan, uin
     {
         if ((cbRESULT_OK == nResult) && (NSP_FOUND == cbGetNspStatus(nProc)))
         {
+#ifndef CBPROTO_311
             chaninfo.cbpkt_header.instrument = nProc - 1;
+#endif
             nResult = cbSendPacket(&chaninfo, nInstance);
         }
     }
@@ -2107,7 +2157,9 @@ cbRESULT cbSetAinpOpts(uint32_t chan, const uint32_t ainpopts,  uint32_t LNCrate
     chaninfo.cbpkt_header.chid		 = 0x8000;
     chaninfo.cbpkt_header.type		 = cbPKTTYPE_CHANSETAINP;
     chaninfo.cbpkt_header.dlen		 = cbPKTDLEN_CHANINFOSHORT;
+#ifndef CBPROTO_311
     chaninfo.cbpkt_header.instrument = cb_cfg_buffer_ptr[nIdx]->chaninfo[chan - 1].cbpkt_header.instrument;
+#endif
     chaninfo.chan        = cb_cfg_buffer_ptr[nIdx]->chaninfo[chan - 1].chan;
     chaninfo.ainpopts    = ainpopts;
     chaninfo.lncrate	 = LNCrate;
@@ -2157,7 +2209,9 @@ cbRESULT cbSetAinpScaling(uint32_t chan, cbSCALING *scalin, uint32_t nInstance)
     chaninfo.cbpkt_header.chid      = 0x8000;
     chaninfo.cbpkt_header.type      = cbPKTTYPE_CHANSETSCALE;
     chaninfo.cbpkt_header.dlen      = cbPKTDLEN_CHANINFO;
+#ifndef CBPROTO_311
     chaninfo.cbpkt_header.instrument = cbGetChanInstrument(chan) - 1;
+#endif
     chaninfo.chan      = cb_cfg_buffer_ptr[nIdx]->chaninfo[chan - 1].chan;
     chaninfo.scalin    = *scalin;
     chaninfo.scalout   = cb_cfg_buffer_ptr[nIdx]->chaninfo[chan - 1].scalout;
@@ -2209,7 +2263,9 @@ cbRESULT cbSetAinpDisplay( uint32_t chan, int32_t smpdispmin, int32_t smpdispmax
     chaninfo.cbpkt_header.chid      = 0x8000;
     chaninfo.cbpkt_header.type      = cbPKTTYPE_CHANSETDISP;
     chaninfo.cbpkt_header.dlen      = cbPKTDLEN_CHANINFO;
+#ifndef CBPROTO_311
     chaninfo.cbpkt_header.instrument = cb_cfg_buffer_ptr[nIdx]->chaninfo[chan - 1].cbpkt_header.instrument;
+#endif
     chaninfo.chan = cb_cfg_buffer_ptr[nIdx]->chaninfo[chan - 1].chan;
     if (smpdispmin) chaninfo.smpdispmin = smpdispmin;
         else chaninfo.smpdispmin = cb_cfg_buffer_ptr[nIdx]->chaninfo[chan - 1].smpdispmin;
@@ -2271,7 +2327,9 @@ cbRESULT cbSetAinpPreview(uint32_t chan, uint32_t prevopts, uint32_t nInstance)
         {
             if ((cbRESULT_OK == res) && (NSP_FOUND == cbGetNspStatus(nProc)))
             {
+#ifndef CBPROTO_311
                 packet.cbpkt_header.instrument = nProc - 1;
+#endif
                 res = cbSendPacket(&packet, nInstance);
             }
         }
@@ -2279,7 +2337,9 @@ cbRESULT cbSetAinpPreview(uint32_t chan, uint32_t prevopts, uint32_t nInstance)
     else
     {
         packet.cbpkt_header.chid = 0x8000 + cb_cfg_buffer_ptr[nIdx]->chaninfo[chan - 1].chan;
+#ifndef CBPROTO_311
         packet.cbpkt_header.instrument = cbGetChanInstrument(chan) - 1;
+#endif
 
         // Enter the packet into the XMT buffer queue
         res = cbSendPacket(&packet, nInstance);
@@ -2327,7 +2387,9 @@ cbRESULT cbSetAinpSampling(uint32_t chan, uint32_t filter, uint32_t group, uint3
     chaninfo.cbpkt_header.chid      = 0x8000;
     chaninfo.cbpkt_header.type      = cbPKTTYPE_CHANSETSMP;
     chaninfo.cbpkt_header.dlen      = cbPKTDLEN_CHANINFO;
+#ifndef CBPROTO_311
     chaninfo.cbpkt_header.instrument = cb_cfg_buffer_ptr[nIdx]->chaninfo[chan - 1].cbpkt_header.instrument;
+#endif
     chaninfo.chan = cb_cfg_buffer_ptr[nIdx]->chaninfo[chan - 1].chan;
     chaninfo.smpfilter = filter;
     chaninfo.smpgroup  = group;
@@ -2394,7 +2456,9 @@ cbRESULT cbSetAinpSpikeOptions(uint32_t chan, uint32_t spkopts, uint32_t spkfilt
     chaninfo.cbpkt_header.chid      = 0x8000;
     chaninfo.cbpkt_header.type      = cbPKTTYPE_CHANSETSPK;
     chaninfo.cbpkt_header.dlen      = cbPKTDLEN_CHANINFO;
+#ifndef CBPROTO_311
     chaninfo.cbpkt_header.instrument = cb_cfg_buffer_ptr[nIdx]->chaninfo[chan - 1].cbpkt_header.instrument;
+#endif
     chaninfo.chan = cb_cfg_buffer_ptr[nIdx]->chaninfo[chan - 1].chan;
     chaninfo.spkopts   = spkopts;
     chaninfo.spkfilter = spkfilter;
@@ -2447,7 +2511,9 @@ cbRESULT cbSetAinpSpikeThreshold(uint32_t chan, int32_t spkthrlevel, uint32_t nI
     chaninfo.cbpkt_header.chid        = 0x8000;
     chaninfo.cbpkt_header.type        = cbPKTTYPE_CHANSETSPKTHR;
     chaninfo.cbpkt_header.dlen        = cbPKTDLEN_CHANINFO;
+#ifndef CBPROTO_311
     chaninfo.cbpkt_header.instrument = cb_cfg_buffer_ptr[nIdx]->chaninfo[chan - 1].cbpkt_header.instrument;
+#endif
     chaninfo.chan = cb_cfg_buffer_ptr[nIdx]->chaninfo[chan - 1].chan;
     chaninfo.spkthrlevel = spkthrlevel;
 
@@ -2494,7 +2560,9 @@ cbRESULT cbSetAinpSpikeHoops(uint32_t chan, cbHOOP *hoops, uint32_t nInstance)
     chaninfo.cbpkt_header.chid        = 0x8000;
     chaninfo.cbpkt_header.type        = cbPKTTYPE_CHANSETSPKHPS;
     chaninfo.cbpkt_header.dlen        = cbPKTDLEN_CHANINFO;
+#ifndef CBPROTO_311
     chaninfo.cbpkt_header.instrument = cb_cfg_buffer_ptr[nIdx]->chaninfo[chan - 1].cbpkt_header.instrument;
+#endif
     chaninfo.chan = cb_cfg_buffer_ptr[nIdx]->chaninfo[chan - 1].chan;
 
     memcpy(&(chaninfo.spkhoops[0][0]), hoops, sizeof(cbHOOP)*cbMAXUNITS*cbMAXHOOPS );
@@ -2570,7 +2638,9 @@ cbRESULT cbSetAoutScaling(uint32_t chan, cbSCALING *scalout, uint32_t nInstance)
     chaninfo.cbpkt_header.chid      = 0x8000;
     chaninfo.cbpkt_header.type      = cbPKTTYPE_CHANSETSCALE;
     chaninfo.cbpkt_header.dlen      = cbPKTDLEN_CHANINFO;
+#ifndef CBPROTO_311
     chaninfo.cbpkt_header.instrument = cb_cfg_buffer_ptr[nIdx]->chaninfo[chan - 1].cbpkt_header.instrument;
+#endif
     chaninfo.chan = cb_cfg_buffer_ptr[nIdx]->chaninfo[chan - 1].chan;
     chaninfo.scalin    = cb_cfg_buffer_ptr[nIdx]->chaninfo[chan - 1].scalin;
     chaninfo.scalout   = *scalout;
@@ -2595,7 +2665,11 @@ cbRESULT cbGetAoutOptions(uint32_t chan, uint32_t *options, uint32_t *monchan, u
 
     // Return the requested data from the rec buffer
     if (options) *options = cb_cfg_buffer_ptr[nIdx]->chaninfo[chan - 1].aoutopts;
+#ifdef CBPROTO_311
+    if (monchan) *monchan = (cb_cfg_buffer_ptr[nIdx]->chaninfo[chan - 1].monsource >> 16) & 0xFFFF;
+#else
     if (monchan) *monchan = cbGetExpandedChannelNumber(cb_cfg_buffer_ptr[nIdx]->chaninfo[chan - 1].moninst + 1, cb_cfg_buffer_ptr[nIdx]->chaninfo[chan - 1].monchan);
+#endif
     if (value)   *value   = cb_cfg_buffer_ptr[nIdx]->chaninfo[chan - 1].outvalue;
 
     return cbRESULT_OK;
@@ -2626,18 +2700,26 @@ cbRESULT cbSetAoutOptions(uint32_t chan, uint32_t options, uint32_t monchan, uin
     chaninfo.cbpkt_header.chid       = 0x8000;
     chaninfo.cbpkt_header.type       = cbPKTTYPE_CHANSETAOUT;
     chaninfo.cbpkt_header.dlen       = cbPKTDLEN_CHANINFO;
+#ifndef CBPROTO_311
     chaninfo.cbpkt_header.instrument = cb_cfg_buffer_ptr[nIdx]->chaninfo[chan - 1].cbpkt_header.instrument;
+#endif
     chaninfo.chan       = cb_cfg_buffer_ptr[nIdx]->chaninfo[chan - 1].chan;
     chaninfo.aoutopts   = options;
+#ifdef CBPROTO_311
+    chaninfo.monsource = (0 == monchan) ? 0 : cbGetInstrumentLocalChannelNumber(monchan);
+#else
     chaninfo.moninst = (0 == monchan) ? 0 : cbGetChanInstrument(monchan) - 1;
     chaninfo.monchan = (0 == monchan) ? 0 : cbGetInstrumentLocalChannelNumber(monchan);
+#endif
     chaninfo.outvalue   = value;
 
     for (int nProc = cbNSP1; nProc <= cbMAXPROCS; ++nProc)
     {
         if ((cbRESULT_OK == nResult) && (NSP_FOUND == cbGetNspStatus(nProc)))
         {
+#ifndef CBPROTO_311
             chaninfo.cbpkt_header.instrument = nProc - 1;
+#endif
             nResult = cbSendPacket(&chaninfo, nInstance);
         }
     }
@@ -2666,7 +2748,9 @@ cbRESULT cbGetSortingModel(uint32_t nInstance)
     {
         if ((cbRESULT_OK == ret) && (NSP_FOUND == cbGetNspStatus(nProc)))
         {
+#ifndef CBPROTO_311
             isPkt.cbpkt_header.instrument = nProc - 1;
+#endif
             ret = cbSendPacket(&isPkt, nInstance);
         }
     }
@@ -2704,7 +2788,9 @@ cbRESULT cbGetFeatureSpaceDomain(uint32_t nInstance)
     {
         if ((cbRESULT_OK == ret) && (NSP_FOUND == cbGetNspStatus(nProc)))
         {
+#ifndef CBPROTO_311
             isPkt.cbpkt_header.instrument = nProc - 1;
+#endif
             ret = cbSendPacket(&isPkt, nInstance);
         }
     }
@@ -2842,7 +2928,9 @@ cbRESULT cbSSSetNoiseBoundary(uint32_t chanIdx, float afCentroid[3], float afMaj
                            afMinor_1[0], afMinor_1[1], afMinor_1[2],
                            afMinor_2[0], afMinor_2[1], afMinor_2[2]);
     icPkt.chan = cb_cfg_buffer_ptr[nIdx]->chaninfo[chanIdx - 1].chan;
+#ifndef CBPROTO_311
     icPkt.cbpkt_header.instrument = cb_cfg_buffer_ptr[nIdx]->chaninfo[chanIdx - 1].cbpkt_header.instrument;
+#endif
 
     return cbSendPacket(&icPkt, nInstance);
 }
@@ -3052,7 +3140,9 @@ cbRESULT cbSSSetStatistics(uint32_t nUpdateSpikes, uint32_t nAutoalg, uint32_t n
     {
         if ((cbRESULT_OK == cbRes) && (NSP_FOUND == cbGetNspStatus(nProc)))
         {
+#ifndef CBPROTO_311
             icPkt.cbpkt_header.instrument = nProc - 1;
+#endif
             cbRes = cbSendPacket(&icPkt, nInstance);
         }
     }
@@ -3108,7 +3198,9 @@ cbRESULT cbSSSetArtifactReject(uint32_t nMaxChans, uint32_t nRefractorySamples, 
     {
         if ((cbRESULT_OK == cbRes) && (NSP_FOUND == cbGetNspStatus(nProc)))
         {
+#ifndef CBPROTO_311
             isPkt.cbpkt_header.instrument = nProc - 1;
+#endif
             cbRes = cbSendPacket(&isPkt, nInstance);
         }
     }
@@ -3166,7 +3258,9 @@ cbRESULT cbSSSetDetect(float fThreshold, float fScaling, uint32_t nInstance)
     {
         if ((cbRESULT_OK == cbRes) && (NSP_FOUND == cbGetNspStatus(nProc)))
         {
+#ifndef CBPROTO_311
             isPkt.cbpkt_header.instrument = nProc - 1;
+#endif
             cbRes = cbSendPacket(&isPkt, nInstance);
         }
     }
@@ -3225,7 +3319,9 @@ cbRESULT cbSSSetStatus(cbAdaptControl cntlUnitStats, cbAdaptControl cntlNumUnits
     {
         if ((cbRESULT_OK == cbRes) && (NSP_FOUND == cbGetNspStatus(nProc)))
         {
+#ifndef CBPROTO_311
             icPkt.cbpkt_header.instrument = nProc - 1;
+#endif
             cbRes = cbSendPacket(&icPkt, nInstance);
         }
     }
@@ -3475,7 +3571,9 @@ cbRESULT cbSetAdaptFilter(uint32_t  proc,             // which NSP processor?
     if (pnRefChan2)     nRefChan2 =     *pnRefChan2;
 
     PktAdaptFiltInfo icPkt(nMode, dLearningRate, nRefChan1, nRefChan2);
+#ifndef CBPROTO_311
     icPkt.cbpkt_header.instrument = proc - 1;
+#endif
     return cbSendPacket(&icPkt, nInstance);
 }
 

--- a/cbhwlib/cbhwlib.cpp
+++ b/cbhwlib/cbhwlib.cpp
@@ -3693,6 +3693,7 @@ cbRESULT CreateSharedObjects(uint32_t nInstance)
         const uint32_t cbXMT_LOCAL_BUFFSTRUCTSIZE  = sizeof(cbXMTBUFF) + (sizeof(uint32_t)*cbXMT_LOCAL_BUFFLEN);
 
         // create the global transmit buffer space
+        memset(buf, 0, sizeof(buf));  // Clear buffer name
         if (nInstance == 0)
             _snprintf(buf, sizeof(buf), "%s", GLOBAL_XMT_NAME);
         else
@@ -3706,6 +3707,7 @@ cbRESULT CreateSharedObjects(uint32_t nInstance)
             return cbRESULT_BUFGXMTALLOCERR;
 
         // create the local transmit buffer space
+        memset(buf, 0, sizeof(buf));  // Clear buffer name
         if (nInstance == 0)
             _snprintf(buf, sizeof(buf), "%s", LOCAL_XMT_NAME);
         else
@@ -3733,6 +3735,7 @@ cbRESULT CreateSharedObjects(uint32_t nInstance)
     }
 
     // Create the shared configuration buffer; if unsuccessful, release rec buffer and return FALSE
+    memset(buf, 0, sizeof(buf));  // Clear buffer name
     if (nInstance == 0)
         _snprintf(buf, sizeof(buf), "%s", CFG_BUF_NAME);
     else
@@ -3745,6 +3748,7 @@ cbRESULT CreateSharedObjects(uint32_t nInstance)
     memset(cb_cfg_buffer_ptr[nIdx], 0, sizeof(cbCFGBUFF));
 
     // Create the shared pc status buffer; if unsuccessful, release rec buffer and return FALSE
+    memset(buf, 0, sizeof(buf));  // Clear buffer name
     if (nInstance == 0)
         _snprintf(buf, sizeof(buf), "%s", STATUS_BUF_NAME);
     else
@@ -3757,6 +3761,7 @@ cbRESULT CreateSharedObjects(uint32_t nInstance)
     memset(cb_pc_status_buffer_ptr[nIdx], 0, sizeof(cbPcStatus));
 
     // Create the shared spike cache buffer; if unsuccessful, release rec buffer and return FALSE
+    memset(buf, 0, sizeof(buf));  // Clear buffer name
     if (nInstance == 0)
         _snprintf(buf, sizeof(buf), "%s", SPK_BUF_NAME);
     else

--- a/cbhwlib/cbhwlib.cpp
+++ b/cbhwlib/cbhwlib.cpp
@@ -1077,6 +1077,7 @@ cbRESULT cbSetComment(uint8_t charset, uint32_t rgba, PROCTIME time, const char*
 #ifndef CBPROTO_311
     pktComment.rgba = rgba;
     pktComment.timeStarted = time;
+// else pktComment.info.flags, pktComment.data
 #endif
     uint32_t nLen = 0;
     if (comment)

--- a/cbhwlib/cbhwlib.cpp
+++ b/cbhwlib/cbhwlib.cpp
@@ -333,7 +333,7 @@ cbRESULT cbOpen(bool bStandAlone, uint32_t nInstance)
     // If it is stand alone application
     if (bStandAlone)
     {
-        // Aquire lock
+        // Acquire lock
         cbRet = cbAquireSystemLock(szLockName, cb_sys_lock_hnd[nInstance]);
         if (cbRet)
             return cbRet;
@@ -363,7 +363,11 @@ cbRESULT cbOpen(bool bStandAlone, uint32_t nInstance)
         _snprintf(cb_rec_buffer_hnd[nIdx].name, sizeof(cb_rec_buffer_hnd[nIdx].name), "%s%d", REC_BUF_NAME, nInstance);
     OpenSharedBuffer(cb_rec_buffer_hnd[nIdx], true);
     cb_rec_buffer_ptr[nIdx] = (cbRECBUFF*)GetSharedBuffer(cb_rec_buffer_hnd[nIdx].hnd, true);
-    if (cb_rec_buffer_ptr[nIdx] == NULL) {  cbClose(false, nInstance);  return cbRESULT_LIBINITERROR; }
+    if (cb_rec_buffer_ptr[nIdx] == NULL)
+    {
+        cbClose(false, nInstance);
+        return cbRESULT_LIBINITERROR;
+    }
 
 
     if (nInstance == 0)
@@ -373,16 +377,24 @@ cbRESULT cbOpen(bool bStandAlone, uint32_t nInstance)
     // Create the shared global transmit buffer; if unsuccessful, release rec buffer and return FALSE
     OpenSharedBuffer(cb_xmt_global_buffer_hnd[nIdx], false);
     cb_xmt_global_buffer_ptr[nIdx] = (cbXMTBUFF*)GetSharedBuffer(cb_xmt_global_buffer_hnd[nIdx].hnd, false);
-    if (cb_xmt_global_buffer_ptr[nIdx] == NULL) {  cbClose(false, nInstance);  return cbRESULT_LIBINITERROR; }
+    if (cb_xmt_global_buffer_ptr[nIdx] == NULL)
+    {
+        cbClose(false, nInstance);
+        return cbRESULT_LIBINITERROR;
+    }
 
     if (nInstance == 0)
         _snprintf(cb_xmt_local_buffer_hnd[nIdx].name, sizeof(cb_xmt_local_buffer_hnd[nIdx].name), "%s", LOCAL_XMT_NAME);
     else
         _snprintf(cb_xmt_local_buffer_hnd[nIdx].name, sizeof(cb_xmt_local_buffer_hnd[nIdx].name), "%s%d", LOCAL_XMT_NAME, nInstance);
     // Create the shared local transmit buffer; if unsuccessful, release rec buffer and return FALSE
-    OpenSharedBuffer(cb_xmt_local_buffer_hnd[nIdx], false);;
+    OpenSharedBuffer(cb_xmt_local_buffer_hnd[nIdx], false);
     cb_xmt_local_buffer_ptr[nIdx] = (cbXMTBUFF*)GetSharedBuffer(cb_xmt_local_buffer_hnd[nIdx].hnd, false);
-    if (cb_xmt_local_buffer_ptr[nIdx] == NULL) {  cbClose(false, nInstance);  return cbRESULT_LIBINITERROR; }
+    if (cb_xmt_local_buffer_ptr[nIdx] == NULL)
+    {
+        cbClose(false, nInstance);
+        return cbRESULT_LIBINITERROR;
+    }
 
     if (nInstance == 0)
         _snprintf(cb_cfg_buffer_hnd[nIdx].name, sizeof(cb_cfg_buffer_hnd[nIdx].name), "%s", CFG_BUF_NAME);
@@ -391,7 +403,11 @@ cbRESULT cbOpen(bool bStandAlone, uint32_t nInstance)
     // Create the shared neuromatic configuration buffer; if unsuccessful, release rec buffer and return FALSE
     OpenSharedBuffer(cb_cfg_buffer_hnd[nIdx], true);
     cb_cfg_buffer_ptr[nIdx] = (cbCFGBUFF*)GetSharedBuffer(cb_cfg_buffer_hnd[nIdx].hnd, true);
-    if (cb_cfg_buffer_ptr[nIdx] == NULL) {  cbClose(false, nInstance);  return cbRESULT_LIBINITERROR; }
+    if (cb_cfg_buffer_ptr[nIdx] == NULL)
+    {
+        cbClose(false, nInstance);
+        return cbRESULT_LIBINITERROR;
+    }
 
     // Check version of hardware protocol if available
     if (cb_cfg_buffer_ptr[nIdx]->procinfo[0].cbpkt_header.chid != 0) {
@@ -410,9 +426,13 @@ cbRESULT cbOpen(bool bStandAlone, uint32_t nInstance)
     else
         _snprintf(cb_pc_status_buffer_hnd[nIdx].name, sizeof(cb_pc_status_buffer_hnd[nIdx].name), "%s%d", STATUS_BUF_NAME, nInstance);
     // Create the shared pc status buffer; if unsuccessful, release rec buffer and return FALSE
-    OpenSharedBuffer(cb_pc_status_buffer_hnd[nIdx], false);;
+    OpenSharedBuffer(cb_pc_status_buffer_hnd[nIdx], false);
     cb_pc_status_buffer_ptr[nIdx] = (cbPcStatus*)GetSharedBuffer(cb_pc_status_buffer_hnd[nIdx].hnd, false);
-    if (cb_pc_status_buffer_ptr[nIdx] == NULL) {  cbClose(false, nInstance);  return cbRESULT_LIBINITERROR; }
+    if (cb_pc_status_buffer_ptr[nIdx] == NULL)
+    {
+        cbClose(false, nInstance);
+        return cbRESULT_LIBINITERROR;
+    }
 
     // Create the shared spike buffer
     if (nInstance == 0)
@@ -421,7 +441,11 @@ cbRESULT cbOpen(bool bStandAlone, uint32_t nInstance)
         _snprintf(cb_spk_buffer_hnd[nIdx].name, sizeof(cb_spk_buffer_hnd[nIdx].name), "%s%d", SPK_BUF_NAME, nInstance);
     OpenSharedBuffer(cb_spk_buffer_hnd[nIdx], false);
     cb_spk_buffer_ptr[nIdx] = (cbSPKBUFF*)GetSharedBuffer(cb_spk_buffer_hnd[nIdx].hnd, false);
-    if (cb_spk_buffer_ptr[nIdx] == NULL) {  cbClose(false, nInstance);  return cbRESULT_LIBINITERROR; }
+    if (cb_spk_buffer_ptr[nIdx] == NULL)
+    {
+        cbClose(false, nInstance);
+        return cbRESULT_LIBINITERROR;
+    }
 
     // open the data availability signals
     if (nInstance == 0)
@@ -430,7 +454,11 @@ cbRESULT cbOpen(bool bStandAlone, uint32_t nInstance)
         _snprintf(buf, sizeof(buf), "%s%d", SIG_EVT_NAME, nInstance);
 #ifdef WIN32
     cb_sig_event_hnd[nIdx] = OpenEventA(SYNCHRONIZE, TRUE, buf);
-    if (cb_sig_event_hnd[nIdx] == NULL)  {  cbClose(false, nInstance);  return cbRESULT_LIBINITERROR; }
+    if (cb_sig_event_hnd[nIdx] == NULL)
+    {
+        cbClose(false, nInstance);
+        return cbRESULT_LIBINITERROR;
+    }
 #else
     sem_t *sem = sem_open(buf, 0);
     if (sem == SEM_FAILED) {  cbClose(false, nInstance);  return cbRESULT_LIBINITERROR; }

--- a/cbhwlib/cbhwlib.h
+++ b/cbhwlib/cbhwlib.h
@@ -974,19 +974,26 @@ typedef enum _cbStateCCF
 
 // External Global Variables
 
-extern HANDLE      cb_xmt_global_buffer_hnd[cbMAXOPEN];       // Transmit queues to send out of this PC
+typedef struct _cbSharedMemHandle {
+    HANDLE hnd = nullptr;
+    char name[64] = {0};
+    int fd = -1;
+    uint32_t size = 0;
+} cbSharedMemHandle;
+
+extern cbSharedMemHandle  cb_xmt_global_buffer_hnd[cbMAXOPEN];       // Transmit queues to send out of this PC
 extern cbXMTBUFF*  cb_xmt_global_buffer_ptr[cbMAXOPEN];
 
-extern HANDLE      cb_xmt_local_buffer_hnd[cbMAXOPEN];        // Transmit queues only for local (this PC) use
+extern cbSharedMemHandle  cb_xmt_local_buffer_hnd[cbMAXOPEN];        // Transmit queues only for local (this PC) use
 extern cbXMTBUFF*  cb_xmt_local_buffer_ptr[cbMAXOPEN];
 
-extern HANDLE       cb_rec_buffer_hnd[cbMAXOPEN];
+extern cbSharedMemHandle  cb_rec_buffer_hnd[cbMAXOPEN];
 extern cbRECBUFF*   cb_rec_buffer_ptr[cbMAXOPEN];
-extern HANDLE       cb_cfg_buffer_hnd[cbMAXOPEN];
+extern cbSharedMemHandle  cb_cfg_buffer_hnd[cbMAXOPEN];
 extern cbCFGBUFF*   cb_cfg_buffer_ptr[cbMAXOPEN];
-extern HANDLE       cb_pc_status_buffer_hnd[cbMAXOPEN];
+extern cbSharedMemHandle  cb_pc_status_buffer_hnd[cbMAXOPEN];
 extern cbPcStatus*  cb_pc_status_buffer_ptr[cbMAXOPEN];        // parameters dealing with local pc status
-extern HANDLE       cb_spk_buffer_hnd[cbMAXOPEN];
+extern cbSharedMemHandle  cb_spk_buffer_hnd[cbMAXOPEN];
 extern cbSPKBUFF*   cb_spk_buffer_ptr[cbMAXOPEN];
 extern HANDLE       cb_sig_event_hnd[cbMAXOPEN];
 

--- a/cbhwlib/cbhwlib.h
+++ b/cbhwlib/cbhwlib.h
@@ -863,9 +863,9 @@ private:
     uint32_t m_nNumSerialChans;
     uint32_t m_nNumDigoutChans;
     uint32_t m_nNumTotalChans;
+#ifndef CBPROTO_311
     NSP_STATUS  m_nNspStatus[cbMAXPROCS];       // true if the nsp has received a sysinfo from each NSP
     uint32_t m_nNumNTrodesPerInstrument[cbMAXPROCS];
-#ifndef CBPROTO_311
     uint32_t m_nGeminiSystem;   // Used as boolean true if connected to a gemini system
 #endif
 
@@ -887,7 +887,9 @@ public:
         for (uint32_t nProc = 0; nProc < cbMAXPROCS; ++nProc)
         {
             isSelection[nProc].lastchan = 1;
+#ifndef CBPROTO_311
             m_nNspStatus[nProc] = NSP_INIT;
+#endif
         }
     }
     bool IsRecordingBlocked()           { return m_iBlockRecording != 0; }
@@ -902,8 +904,16 @@ public:
     uint32_t cbGetNumSerialChans()      { return m_nNumSerialChans; }
     uint32_t cbGetNumDigoutChans()      { return m_nNumDigoutChans; }
     uint32_t cbGetNumTotalChans()       { return m_nNumTotalChans; }
+
+#ifndef CBPROTO_311
     NSP_STATUS cbGetNspStatus(uint32_t nProc) { return m_nNspStatus[nProc]; }
     uint32_t cbGetNumNTrodesPerInstrument(uint32_t nProc) { return m_nNumNTrodesPerInstrument[nProc - 1]; }
+    void cbSetNspStatus(uint32_t nInstrument, NSP_STATUS nStatus) { m_nNspStatus[nInstrument] = nStatus; }
+    void cbSetNumNTrodesPerInstrument(uint32_t nInstrument, uint32_t nNumNTrodesPerInstrument) { m_nNumNTrodesPerInstrument[nInstrument - 1] = nNumNTrodesPerInstrument; }
+#else
+    // m_NspStatus not avail in 3.11 so set to always found to pass logic checks.
+    NSP_STATUS cbGetNspStatus(uint32_t nProc) { return NSP_FOUND; }
+#endif
     void SetBlockRecording(bool bBlockRecording)                { m_iBlockRecording += bBlockRecording ? 1 : -1; }
     void cbSetPCStatusFlags(uint32_t nPCStatusFlags)            { m_nPCStatusFlags = nPCStatusFlags; }
     void cbSetNumFEChans(uint32_t nNumFEChans)                  { m_nNumFEChans = nNumFEChans; }
@@ -916,8 +926,6 @@ public:
     void cbSetNumSerialChans(uint32_t nNumSerialChans)          { m_nNumSerialChans = nNumSerialChans; }
     void cbSetNumDigoutChans(uint32_t nNumDigoutChans)          { m_nNumDigoutChans = nNumDigoutChans; }
     void cbSetNumTotalChans(uint32_t nNumTotalChans)            { m_nNumTotalChans = nNumTotalChans; }
-    void cbSetNspStatus(uint32_t nInstrument, NSP_STATUS nStatus) { m_nNspStatus[nInstrument] = nStatus; }
-    void cbSetNumNTrodesPerInstrument(uint32_t nInstrument, uint32_t nNumNTrodesPerInstrument) { m_nNumNTrodesPerInstrument[nInstrument - 1] = nNumNTrodesPerInstrument; }
 };
 
 typedef struct {

--- a/cbhwlib/cbhwlib.h
+++ b/cbhwlib/cbhwlib.h
@@ -814,6 +814,10 @@ typedef struct {
     uint32_t buffer[0];       // big buffer of data...there are actually "bufferlen"--+ indices
 } cbXMTBUFF;
 
+#define cbXMT_GLOBAL_BUFFLEN    (cbCER_UDP_SIZE_MAX / 4) * 5000 + 2     // room for 500 packets
+#define cbXMT_LOCAL_BUFFLEN     (cbCER_UDP_SIZE_MAX / 4) * 2000 + 2     // room for 200 packets
+
+
 #ifdef _MSC_VER
 #pragma warning(pop)
 #endif

--- a/cbhwlib/cbhwlib.h
+++ b/cbhwlib/cbhwlib.h
@@ -865,6 +865,9 @@ private:
     uint32_t m_nNumTotalChans;
     NSP_STATUS  m_nNspStatus[cbMAXPROCS];       // true if the nsp has received a sysinfo from each NSP
     uint32_t m_nNumNTrodesPerInstrument[cbMAXPROCS];
+#ifndef CBPROTO_311
+    uint32_t m_nGeminiSystem;   // Used as boolean true if connected to a gemini system
+#endif
 
 public:
     cbPcStatus() :

--- a/cbhwlib/cbproto.h
+++ b/cbhwlib/cbproto.h
@@ -236,7 +236,7 @@ typedef int16_t           A2D_DATA;
 // Total (actually 156) (160)   ->  (320)
 //
 #define cbMAXOPEN   4                               // Maximum number of open cbhwlib's (nsp's)
-#ifdef __cplusplus
+#if defined(__cplusplus) && !defined(CBPROTO_311)
 // Client-side defs
 #define cbMAXPROCS  3                               // Number of NSPs for client
 #define cbNUM_FE_CHANS        512                   // Front end channels for client

--- a/cbsdk/SdkApp.h
+++ b/cbsdk/SdkApp.h
@@ -97,6 +97,7 @@ public:
     cbSdkResult SdkGetChannelConfig(uint16_t channel, cbPKT_CHANINFO * chaninfo);
     cbSdkResult SdkGetSampleGroupList(uint32_t proc, uint32_t group, uint32_t *length, uint16_t *list);
     cbSdkResult SdkGetSampleGroupInfo(uint32_t proc, uint32_t group, char *label, uint32_t *period, uint32_t *length);
+    cbSdkResult SdkSetAinpSampling(uint32_t chan, uint32_t filter, uint32_t group);
     cbSdkResult SdkGetFilterDesc(uint32_t proc, uint32_t filt, cbFILTDESC * filtdesc);
     cbSdkResult SdkGetTrackObj(char * name, uint16_t * type, uint16_t * pointCount, uint32_t id);
     cbSdkResult SdkGetVideoSource(char * name, float * fps, uint32_t id);

--- a/cbsdk/SdkApp.h
+++ b/cbsdk/SdkApp.h
@@ -98,6 +98,7 @@ public:
     cbSdkResult SdkGetSampleGroupList(uint32_t proc, uint32_t group, uint32_t *length, uint16_t *list);
     cbSdkResult SdkGetSampleGroupInfo(uint32_t proc, uint32_t group, char *label, uint32_t *period, uint32_t *length);
     cbSdkResult SdkSetAinpSampling(uint32_t chan, uint32_t filter, uint32_t group);
+    cbSdkResult SdkSetAinpSpikeOptions(uint32_t chan, uint32_t flags, uint32_t filter);
     cbSdkResult SdkGetFilterDesc(uint32_t proc, uint32_t filt, cbFILTDESC * filtdesc);
     cbSdkResult SdkGetTrackObj(char * name, uint16_t * type, uint16_t * pointCount, uint32_t id);
     cbSdkResult SdkGetVideoSource(char * name, float * fps, uint32_t id);

--- a/cbsdk/cbsdk.cpp
+++ b/cbsdk/cbsdk.cpp
@@ -3723,7 +3723,6 @@ cbSdkResult SdkApp::SdkSetAinpSampling(uint32_t chan, uint32_t filter, uint32_t 
     return CBSDKRESULT_SUCCESS;
 }
 
-/// sdk stub for SdkApp::SdkSetSpikeConfig
 CBSDKAPI    cbSdkResult cbSdkSetAinpSampling(uint32_t nInstance, uint32_t chan, uint32_t filter, uint32_t group)
 {
     if (chan > cbMAXCHANS || filter >= cbMAXFILTS)
@@ -3733,6 +3732,29 @@ CBSDKAPI    cbSdkResult cbSdkSetAinpSampling(uint32_t nInstance, uint32_t chan, 
     if (g_app[nInstance] == NULL)
         return CBSDKRESULT_CLOSED;
     return g_app[nInstance]->SdkSetAinpSampling(chan, filter, group);
+}
+
+cbSdkResult SdkApp::SdkSetAinpSpikeOptions(uint32_t chan, uint32_t flags, uint32_t filter)
+{
+    if (m_instInfo == 0)
+        return CBSDKRESULT_CLOSED;
+    cbRESULT cbres = cbSetAinpSpikeOptions(chan, flags, filter);
+    if (cbres == cbRESULT_NOLIBRARY)
+        return CBSDKRESULT_CLOSED;
+    if (cbres)
+        return CBSDKRESULT_UNKNOWN;
+    return CBSDKRESULT_SUCCESS;
+}
+
+CBSDKAPI    cbSdkResult cbSdkSetAinpSpikeOptions(uint32_t nInstance, uint32_t chan, uint32_t flags, uint32_t filter)
+{
+    if (chan > cbMAXCHANS || filter >= cbMAXFILTS)
+        return CBSDKRESULT_INVALIDPARAM;
+    if (nInstance >= cbMAXOPEN)
+        return CBSDKRESULT_INVALIDPARAM;
+    if (g_app[nInstance] == NULL)
+        return CBSDKRESULT_CLOSED;
+    return g_app[nInstance]->SdkSetAinpSpikeOptions(chan, flags, filter);
 }
 
 // Author & Date:   Ehsan Azar     30 March 2011

--- a/cbsdk/cbsdk.cpp
+++ b/cbsdk/cbsdk.cpp
@@ -111,21 +111,20 @@ void SdkApp::OnPktGroup(const cbPKT_GROUP * const pkt)
 #ifndef CBPROTO_311
     if (pkt->cbpkt_header.instrument >= cbMAXPROCS)
         nInstrument = 0;
-#endif
-
     for (uint32_t nProc = 0; nProc < cbMAXPROCS; ++nProc)
     {
         if (NSP_FOUND == cbGetNspStatus(nProc + 1))
         {
             if (cbRESULT_OK == ::cbGetProcInfo(nProc + 1, &isProcInfo))
                 nChanProcMax += isProcInfo.chancount;
-#ifndef CBPROTO_311
+
             if (pkt->cbpkt_header.instrument == nProc)
                 break;
-#endif
+
             nChanProcStart = nChanProcMax;
         }
     }
+#endif
 
     // Get information about this group...
     uint32_t  period;

--- a/cbsdk/cbsdk.cpp
+++ b/cbsdk/cbsdk.cpp
@@ -3704,6 +3704,38 @@ CBSDKAPI    cbSdkResult cbSdkSetSpikeConfig(uint32_t nInstance, uint32_t spkleng
 }
 
 // Author & Date:   Ehsan Azar     30 March 2011
+/** Send global spike configuration.
+*
+* @param[in]		spklength		spike length
+* @param[in]		spkpretrig		spike pre-trigger number of samples
+
+* \n This function returns the error code
+*/
+cbSdkResult SdkApp::SdkSetAinpSampling(uint32_t chan, uint32_t filter, uint32_t group)
+{
+    if (m_instInfo == 0)
+        return CBSDKRESULT_CLOSED;
+    cbRESULT cbres = cbSetAinpSampling(chan, filter, group, m_nInstance);
+    if (cbres == cbRESULT_NOLIBRARY)
+        return CBSDKRESULT_CLOSED;
+    if (cbres)
+        return CBSDKRESULT_UNKNOWN;
+    return CBSDKRESULT_SUCCESS;
+}
+
+/// sdk stub for SdkApp::SdkSetSpikeConfig
+CBSDKAPI    cbSdkResult cbSdkSetAinpSampling(uint32_t nInstance, uint32_t chan, uint32_t filter, uint32_t group)
+{
+    if (chan > cbMAXCHANS || filter >= cbMAXFILTS)
+        return CBSDKRESULT_INVALIDPARAM;
+    if (nInstance >= cbMAXOPEN)
+        return CBSDKRESULT_INVALIDPARAM;
+    if (g_app[nInstance] == NULL)
+        return CBSDKRESULT_CLOSED;
+    return g_app[nInstance]->SdkSetAinpSampling(chan, filter, group);
+}
+
+// Author & Date:   Ehsan Azar     30 March 2011
 /** Get global system configuration.
 *
 * @param[out]		spklength		spike length

--- a/cbsdk/cbsdk.cpp
+++ b/cbsdk/cbsdk.cpp
@@ -93,7 +93,10 @@ void SdkApp::OnPktGroup(const cbPKT_GROUP * const pkt)
     uint32_t nChanProcStart = 0;
     uint32_t nChanProcMax = 0;
     cbPROCINFO isProcInfo;
-    uint32_t nInstrument = pkt->cbpkt_header.instrument;
+    uint32_t nInstrument = 0;
+#ifndef CBPROTO_311
+    nInstrument = pkt->cbpkt_header.instrument;
+#endif
     if (IsStandAlone())
         nInstrument = 0;
 
@@ -105,8 +108,10 @@ void SdkApp::OnPktGroup(const cbPKT_GROUP * const pkt)
     if (group >= SMPGRP_RAW)
         return;
 
+#ifndef CBPROTO_311
     if (pkt->cbpkt_header.instrument >= cbMAXPROCS)
         nInstrument = 0;
+#endif
 
     for (uint32_t nProc = 0; nProc < cbMAXPROCS; ++nProc)
     {
@@ -114,8 +119,10 @@ void SdkApp::OnPktGroup(const cbPKT_GROUP * const pkt)
         {
             if (cbRESULT_OK == ::cbGetProcInfo(nProc + 1, &isProcInfo))
                 nChanProcMax += isProcInfo.chancount;
+#ifndef CBPROTO_311
             if (pkt->cbpkt_header.instrument == nProc)
                 break;
+#endif
             nChanProcStart = nChanProcMax;
         }
     }
@@ -287,8 +294,10 @@ void SdkApp::OnPktComment(const cbPKT_COMMENT * const pPkt)
                 uint32_t write_index = m_CMT->write_index;
                 // Store more data
                 m_CMT->charset[write_index]  = pPkt->info.charset;
+#ifndef CBPROTO_311
                 m_CMT->timestamps[write_index] = pPkt->timeStarted;
                 m_CMT->rgba[write_index] = pPkt->rgba;
+#endif
 
                 strncpy((char *)m_CMT->comments[write_index], (const char *)(&pPkt->comment[0]), cbMAX_COMMENT);
                 m_CMT->write_index = new_write_index;
@@ -2836,8 +2845,9 @@ cbSdkResult SdkApp::SdkSetDigitalOutput(uint16_t channel, uint16_t value)
     dopkt.cbpkt_header.chid = 0x8000;
     dopkt.cbpkt_header.type = cbPKTTYPE_SET_DOUTSET;
     dopkt.cbpkt_header.dlen = cbPKTDLEN_SET_DOUT;
+#ifndef CBPROTO_311
     dopkt.cbpkt_header.instrument = cbGetChanInstrument(channel) - 1;
-
+#endif
     // get the channel number
     dopkt.chan = cb_cfg_buffer_ptr[0]->chaninfo[channel - 1].chan;
 
@@ -3207,7 +3217,9 @@ cbSdkResult SdkApp::SdkSetAnalogOutput(uint16_t channel, cbSdkWaveformData * wf,
         wfPkt.cbpkt_header.chid = cbPKTCHAN_CONFIGURATION;
         wfPkt.cbpkt_header.type = cbPKTTYPE_WAVEFORMSET;
         wfPkt.cbpkt_header.dlen = cbPKTDLEN_WAVEFORM;
+#ifndef CBPROTO_311
         wfPkt.cbpkt_header.instrument = cbGetChanInstrument(channel) - 1;
+#endif
         // Set common fields
         wfPkt.mode = wf->type;
         wfPkt.chan = cb_cfg_buffer_ptr[0]->chaninfo[channel - 1].chan;
@@ -3741,7 +3753,9 @@ cbSdkResult SdkApp::SdkSystem(cbSdkSystemType cmd)
     pktsysinfo.cbpkt_header.chid = 0x8000;
     pktsysinfo.cbpkt_header.type = cbPKTTYPE_SYSSETRUNLEV;
     pktsysinfo.cbpkt_header.dlen = cbPKTDLEN_SYSINFO;
+#ifndef CBPROTO_311
     pktsysinfo.cbpkt_header.instrument = 0;
+#endif
     switch (cmd)
     {
     case cbSdkSystem_RESET:

--- a/cbsdk/cbsdk.h
+++ b/cbsdk/cbsdk.h
@@ -543,6 +543,9 @@ CBSDKAPI    cbSdkResult cbSdkGetSampleGroupList(uint32_t nInstance, uint32_t pro
 
 CBSDKAPI    cbSdkResult cbSdkGetSampleGroupInfo(uint32_t nInstance, uint32_t proc, uint32_t group, char *label, uint32_t *period, uint32_t *length);
 
+/// Modify channel's sample group and filter.
+CBSDKAPI    cbSdkResult cbSdkSetAinpSampling(uint32_t nInstance, uint32_t chan, uint32_t filter, uint32_t group);
+
 /*!
 * Get information about given trackable object
 * @param[in] id		trackable ID (1 to cbMAXTRACKOBJ)

--- a/cbsdk/cbsdk.h
+++ b/cbsdk/cbsdk.h
@@ -546,6 +546,9 @@ CBSDKAPI    cbSdkResult cbSdkGetSampleGroupInfo(uint32_t nInstance, uint32_t pro
 /// Modify channel's sample group and filter.
 CBSDKAPI    cbSdkResult cbSdkSetAinpSampling(uint32_t nInstance, uint32_t chan, uint32_t filter, uint32_t group);
 
+/// Modify channel's spike options
+CBSDKAPI    cbSdkResult cbSdkSetAinpSpikeOptions(uint32_t nInstance, uint32_t chan, uint32_t flags, uint32_t filter);
+
 /*!
 * Get information about given trackable object
 * @param[in] id		trackable ID (1 to cbMAXTRACKOBJ)

--- a/samples/TestCBSDK/testcbsdk.cpp
+++ b/samples/TestCBSDK/testcbsdk.cpp
@@ -30,87 +30,87 @@
 
 void handleResult(cbSdkResult res)
 {
-	switch (res)
-	{
-	case CBSDKRESULT_SUCCESS:
-		break;
-	case CBSDKRESULT_CLOSED:
-		printf("Instrument closed\n");
-	case CBSDKRESULT_NOTIMPLEMENTED:
-		printf("Not implemented\n");
-		break;
-	case CBSDKRESULT_INVALIDPARAM:
-		printf("Invalid parameter\n");
-		break;
-	case CBSDKRESULT_WARNOPEN:
-		printf("Real-time interface already initialized\n");
-	case CBSDKRESULT_WARNCLOSED:
-		printf("Real-time interface already closed\n");
-		break;
-	case CBSDKRESULT_ERROPENCENTRAL:
-		printf("Unable to open library for Central interface\n");
-		break;
-	case CBSDKRESULT_ERROPENUDP:
-		printf("Unable to open library for UDP interface\n");
-		break;
-	case CBSDKRESULT_ERROPENUDPPORT:
-		printf("Unable to open UDP interface\n");
-		break;
-	case CBSDKRESULT_OPTERRUDP:
-		printf("Unable to set UDP interface option\n");
-		break;
-	case CBSDKRESULT_MEMERRUDP:
-		printf("Unable to assign UDP interface memory\n"
-			" Consider using sysctl -w net.core.rmem_max=8388608\n"
-			" or sysctl -w kern.ipc.maxsockbuf=8388608\n");
-		break;
-	case CBSDKRESULT_INVALIDINST:
-		printf("Invalid UDP interface\n");
-		break;
-	case CBSDKRESULT_ERRMEMORYTRIAL:
-		printf("Unable to allocate RAM for trial cache data\n");
-		break;
-	case CBSDKRESULT_ERROPENUDPTHREAD:
-		printf("Unable to Create UDP thread\n");
-		break;
-	case CBSDKRESULT_ERROPENCENTRALTHREAD:
-		printf("Unable to start Cerebus real-time data thread\n");
-		break;
-	case CBSDKRESULT_ERRINIT:
-		printf("Library initialization error\n");
-		break;
-	case CBSDKRESULT_ERRMEMORY:
-		printf("Library memory allocation error\n");
-		break;
-	case CBSDKRESULT_TIMEOUT:
-		printf("Connection timeout error\n");
-		break;
-	case CBSDKRESULT_ERROFFLINE:
-		printf("Instrument is offline\n");
-		break;
-	default:
-		printf("Unexpected error (%d)\n", res);
-		break;
-	}
+    switch (res)
+    {
+    case CBSDKRESULT_SUCCESS:
+        break;
+    case CBSDKRESULT_CLOSED:
+        printf("Instrument closed\n");
+    case CBSDKRESULT_NOTIMPLEMENTED:
+        printf("Not implemented\n");
+        break;
+    case CBSDKRESULT_INVALIDPARAM:
+        printf("Invalid parameter\n");
+        break;
+    case CBSDKRESULT_WARNOPEN:
+        printf("Real-time interface already initialized\n");
+    case CBSDKRESULT_WARNCLOSED:
+        printf("Real-time interface already closed\n");
+        break;
+    case CBSDKRESULT_ERROPENCENTRAL:
+        printf("Unable to open library for Central interface\n");
+        break;
+    case CBSDKRESULT_ERROPENUDP:
+        printf("Unable to open library for UDP interface\n");
+        break;
+    case CBSDKRESULT_ERROPENUDPPORT:
+        printf("Unable to open UDP interface\n");
+        break;
+    case CBSDKRESULT_OPTERRUDP:
+        printf("Unable to set UDP interface option\n");
+        break;
+    case CBSDKRESULT_MEMERRUDP:
+        printf("Unable to assign UDP interface memory\n"
+            " Consider using sysctl -w net.core.rmem_max=8388608\n"
+            " or sysctl -w kern.ipc.maxsockbuf=8388608\n");
+        break;
+    case CBSDKRESULT_INVALIDINST:
+        printf("Invalid UDP interface\n");
+        break;
+    case CBSDKRESULT_ERRMEMORYTRIAL:
+        printf("Unable to allocate RAM for trial cache data\n");
+        break;
+    case CBSDKRESULT_ERROPENUDPTHREAD:
+        printf("Unable to Create UDP thread\n");
+        break;
+    case CBSDKRESULT_ERROPENCENTRALTHREAD:
+        printf("Unable to start Cerebus real-time data thread\n");
+        break;
+    case CBSDKRESULT_ERRINIT:
+        printf("Library initialization error\n");
+        break;
+    case CBSDKRESULT_ERRMEMORY:
+        printf("Library memory allocation error\n");
+        break;
+    case CBSDKRESULT_TIMEOUT:
+        printf("Connection timeout error\n");
+        break;
+    case CBSDKRESULT_ERROFFLINE:
+        printf("Instrument is offline\n");
+        break;
+    default:
+        printf("Unexpected error (%d)\n", res);
+        break;
+    }
 }
 
 
 cbSdkVersion testGetVersion(void)
 {
-	// Library version can be read even before library open (return value is a warning)
-	//  actual NSP version however needs library to be open
-	cbSdkVersion ver;
-	cbSdkResult res = cbSdkGetVersion(INST, &ver);
-	if (res != CBSDKRESULT_SUCCESS)
-	{
-		printf("Unable to determine instrument version\n");
-	}
-	else {
-		printf("Initializing Cerebus real-time interface %d.%02d.%02d.%02d (protocol cb%d.%02d)...\n",
+    // Library version can be read even before library open (return value is a warning)
+    //  actual NSP version however needs library to be open
+    cbSdkVersion ver;
+    cbSdkResult res = cbSdkGetVersion(INST, &ver);
+    if (res != CBSDKRESULT_SUCCESS)
+    {
+        printf("Unable to determine instrument version\n");
+    }
+    else {
+        printf("Initializing Cerebus real-time interface %d.%02d.%02d.%02d (protocol cb%d.%02d)...\n",
                ver.major, ver.minor, ver.release, ver.beta, ver.majorp, ver.minorp);
-	}
-	handleResult(res);
-	return ver;
+    }
+    handleResult(res);
+    return ver;
 }
 
 // Author & Date:   Ehsan Azar    24 Oct 2012
@@ -120,27 +120,27 @@ cbSdkResult testOpen(LPCSTR inst_ip, int inst_port, LPCSTR client_ip)
     // Try to get the version. Should be a warning because we are not yet open.
     cbSdkVersion ver = testGetVersion();
 
-	// Open the device using default connection type.
-	cbSdkConnectionType conType = CBSDKCONNECTION_DEFAULT;
-	cbSdkConnection con = cbSdkConnection();
-	con.szOutIP = inst_ip;
+    // Open the device using default connection type.
+    cbSdkConnectionType conType = CBSDKCONNECTION_DEFAULT;
+    cbSdkConnection con = cbSdkConnection();
+    con.szOutIP = inst_ip;
     con.nOutPort = inst_port;
-	con.szInIP = client_ip;
-	cbSdkResult res = cbSdkOpen(INST, conType, con);
-	if (res != CBSDKRESULT_SUCCESS)
-		printf("Unable to open instrument connection.\n");
-	handleResult(res);
+    con.szInIP = client_ip;
+    cbSdkResult res = cbSdkOpen(INST, conType, con);
+    if (res != CBSDKRESULT_SUCCESS)
+        printf("Unable to open instrument connection.\n");
+    handleResult(res);
 
-	cbSdkInstrumentType instType;
+    cbSdkInstrumentType instType;
     if (res >= 0)
     {
         // Return the actual opened connection
         res = cbSdkGetType(INST, &conType, &instType);
-		if (res != CBSDKRESULT_SUCCESS)
-			printf("Unable to determine connection type\n");
-		handleResult(res);
-		// if (instType == CBSDKINSTRUMENT_NPLAY || instType == CBSDKINSTRUMENT_REMOTENPLAY)
-		//  	printf("Unable to open UDP interface to nPlay\n");
+        if (res != CBSDKRESULT_SUCCESS)
+            printf("Unable to determine connection type\n");
+        handleResult(res);
+        // if (instType == CBSDKINSTRUMENT_NPLAY || instType == CBSDKINSTRUMENT_REMOTENPLAY)
+        //      printf("Unable to open UDP interface to nPlay\n");
         
 
         if (conType < 0 || conType > CBSDKCONNECTION_CLOSED)
@@ -151,10 +151,10 @@ cbSdkResult testOpen(LPCSTR inst_ip, int inst_port, LPCSTR client_ip)
         char strConnection[CBSDKCONNECTION_COUNT + 1][8] = {"Default", "Central", "Udp", "Closed", "Unknown"};
         char strInstrument[CBSDKINSTRUMENT_COUNT + 1][13] = {"NSP", "nPlay", "Local NSP", "Remote nPlay", "Unknown"};
 
-		// Now that we are open, get the version again.
-		ver = testGetVersion();
+        // Now that we are open, get the version again.
+        ver = testGetVersion();
 
-		// Summary results.
+        // Summary results.
         printf("%s real-time interface to %s (%d.%02d.%02d.%02d; proto %d.%02d) successfully initialized\n",
                strConnection[conType], strInstrument[instType],
                ver.nspmajor, ver.nspminor, ver.nsprelease, ver.nspbeta,
@@ -167,19 +167,19 @@ cbSdkResult testOpen(LPCSTR inst_ip, int inst_port, LPCSTR client_ip)
 
 cbSdkResult testGetConfig(void)
 {
-	uint32_t proc = 1;
-	uint32_t nChansInGroup;
-	uint16_t pGroupList[cbNUM_ANALOG_CHANS];
+    uint32_t proc = 1;
+    uint32_t nChansInGroup;
+    uint16_t pGroupList[cbNUM_ANALOG_CHANS];
     cbSdkResult res = CBSDKRESULT_SUCCESS;
-	for (uint32_t group_ix = 1; group_ix < 7; group_ix++)
-	{
-		res = cbSdkGetSampleGroupList(INST, proc, group_ix, &nChansInGroup, pGroupList);
-		if (res == CBSDKRESULT_SUCCESS)
-		{
-			printf("In sampling group %d, found %d channels.\n", group_ix, nChansInGroup);
-		}
-		handleResult(res);
-	}
+    for (uint32_t group_ix = 1; group_ix < 7; group_ix++)
+    {
+        res = cbSdkGetSampleGroupList(INST, proc, group_ix, &nChansInGroup, pGroupList);
+        if (res == CBSDKRESULT_SUCCESS)
+        {
+            printf("In sampling group %d, found %d channels.\n", group_ix, nChansInGroup);
+        }
+        handleResult(res);
+    }
     return res;
 }
 
@@ -188,15 +188,15 @@ cbSdkResult testGetConfig(void)
 cbSdkResult testClose(void)
 {
     cbSdkResult res = cbSdkClose(INST);
-	if (res == CBSDKRESULT_SUCCESS)
-	{
-		printf("Interface closed successfully\n");
-	}
-	else
-	{
-		printf("Unable to close interface.\n");
-		handleResult(res);
-	}
+    if (res == CBSDKRESULT_SUCCESS)
+    {
+        printf("Interface closed successfully\n");
+    }
+    else
+    {
+        printf("Unable to close interface.\n");
+        handleResult(res);
+    }
     return res;
 }
 
@@ -204,12 +204,12 @@ cbSdkResult testClose(void)
 // The test suit main entry
 int main(int argc, char *argv[])
 {
-	LPCSTR inst_ip = "";
+    LPCSTR inst_ip = "";
     int inst_port = cbNET_UDP_PORT_CNT;
-	LPCSTR client_ip = "";
-	if (argc > 1) {inst_ip = argv[1];}
+    LPCSTR client_ip = "";
+    if (argc > 1) {inst_ip = argv[1];}
     if (argc > 2) {inst_port = strtol(argv[2], NULL, 10);}
-	if (argc > 3) { client_ip = argv[3]; }
+    if (argc > 3) { client_ip = argv[3]; }
     cbSdkResult res = testOpen(inst_ip, inst_port, client_ip);
     if (res < 0)
     {
@@ -218,8 +218,8 @@ int main(int argc, char *argv[])
     }
     else
         printf("testOpen succeeded\n");
-	
-	res = testGetConfig();
+
+    res = testGetConfig();
     if (res < 0)
     {
         printf("testGetConfig failed (%d)!\n", res);

--- a/samples/TestCBSDK/testcbsdk.cpp
+++ b/samples/TestCBSDK/testcbsdk.cpp
@@ -106,7 +106,8 @@ cbSdkVersion testGetVersion(void)
 		printf("Unable to determine instrument version\n");
 	}
 	else {
-		printf("Initializing Cerebus real-time interface %d.%02d.%02d.%02d (protocol cb%d.%02d)...\n", ver.major, ver.minor, ver.release, ver.beta, ver.majorp, ver.minorp);
+		printf("Initializing Cerebus real-time interface %d.%02d.%02d.%02d (protocol cb%d.%02d)...\n",
+               ver.major, ver.minor, ver.release, ver.beta, ver.majorp, ver.minorp);
 	}
 	handleResult(res);
 	return ver;
@@ -154,7 +155,10 @@ cbSdkResult testOpen(LPCSTR inst_ip, int inst_port, LPCSTR client_ip)
 		ver = testGetVersion();
 
 		// Summary results.
-        printf("%s real-time interface to %s (%d.%02d.%02d.%02d) successfully initialized\n", strConnection[conType], strInstrument[instType], ver.nspmajor, ver.nspminor, ver.nsprelease, ver.nspbeta);
+        printf("%s real-time interface to %s (%d.%02d.%02d.%02d; proto %d.%02d) successfully initialized\n",
+               strConnection[conType], strInstrument[instType],
+               ver.nspmajor, ver.nspminor, ver.nsprelease, ver.nspbeta,
+               ver.nspmajorp, ver.nspminorp);
     }
 
     return res;

--- a/samples/TestIO/test_io.cpp
+++ b/samples/TestIO/test_io.cpp
@@ -204,9 +204,10 @@ void testSetConfig(bool bCont, bool bEv)
         cbPKT_CHANINFO ch_info;
         cbSdkResult res;
         for (int chan_ix = 0; chan_ix < cbNUM_ANALOG_CHANS; ++chan_ix) {
-            res = cbSdkGetChannelConfig(INST, chan_ix + 1, &ch_info);
-            ch_info.smpgroup = chan_ix < 10 ? 5 : 0;
-            res = cbSdkSetChannelConfig(INST, chan_ix + 1, &ch_info);
+            res = cbSdkSetAinpSampling(INST, chan_ix + 1, 0, chan_ix < 10 ? 5 : 0);
+//            res = cbSdkGetChannelConfig(INST, chan_ix + 1, &ch_info);
+//            ch_info.smpgroup = chan_ix < 10 ? 5 : 0;
+//            res = cbSdkSetChannelConfig(INST, chan_ix + 1, &ch_info);
         }
     }
 }


### PR DESCRIPTION
This adds an option to set a preprocessor directive `CBPROTO_311` and, when it is set, CereLink will be compatible with protocol 3.11 (found on firmwares 7.0x).
Fixes #141 

I will not be adding Python support to the 3.11 support, so I may never merge this PR. I'll keep this PR here though to rebase when master changes.

TODO:
- [ ] Modify CI script for additional `-DCBPROTO_311=ON` builds with well-named artifacts.
- [ ] ~cerebus.cbpy built for protocol 3.11~ <-- I do not plan on doing this