### PR TITLE
Speed up STANDALONE UDP reception, and stop the false drop alarm

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -92,6 +92,7 @@ endif(CBSDK_BUILD_TEST)
 ##########################################################################################
 # Validation Tools
 add_subdirectory(tools/validate_clock_sync)
+add_subdirectory(tools/rx_bench)
 
 ##########################################################################################
 # Sample Applications for New Architecture

--- a/src/cbdev/src/device_session.cpp
+++ b/src/cbdev/src/device_session.cpp
@@ -295,11 +295,24 @@ struct DeviceSession::Impl {
     std::atomic<bool> has_callbacks{false};  // Fast-path skip when no callbacks registered
     CallbackHandle next_callback_handle = 1;  // 0 is reserved for "invalid"
 
-    // Protocol monitor — dropped packet detection
+    // Protocol monitor — dropped packet detection.
+    //
+    // The device reports, in each cbPKT_SYSPROTOCOLMONITOR, how many packets it
+    // sent since the previous one.  Comparing that to our own count per
+    // interval is NOT a loss measurement: a packet sent just before the monitor
+    // can be reassembled just after it, which shows up as a shortfall in one
+    // interval and an exactly matching surplus in the next.  Measured against
+    // Gemini hubs, that boundary straddling alone produced a steady stream of
+    // "dropped N packets" reports while the running totals agreed exactly.
+    //
+    // So track the running balance instead: accumulate sent and received across
+    // all intervals and report the cumulative difference.  Straddled packets
+    // cancel out on the next interval; genuine loss does not.
     uint32_t pkts_since_monitor = 0;       // Packets counted since last SYSPROTOCOLMONITOR
     bool first_monitor_seen = false;        // Skip comparison until first baseline is established
-    uint32_t dropped_accum = 0;             // Drops accumulated since last log
-    uint32_t sent_accum = 0;                // Sent accumulated since last log
+    uint64_t sent_total = 0;                // Device-reported packets sent, all intervals
+    uint64_t recv_total = 0;                // Packets we counted over the same intervals
+    uint64_t reported_lost = 0;             // Cumulative loss already reported
     std::chrono::steady_clock::time_point last_drop_log_time{};
 
     // Receive thread state
@@ -1608,16 +1621,23 @@ void DeviceSession::updateConfigFromBuffer(const void* buffer, const size_t byte
                 // giving it an undefined timestamp delay.
                 const auto* mon = reinterpret_cast<const cbPKT_SYSPROTOCOLMONITOR*>(buff_bytes + offset);
                 if (m_impl->first_monitor_seen && mon->sentpkts > 0) {
-                    const uint32_t received = m_impl->pkts_since_monitor;
-                    if (received < mon->sentpkts) {
-                        m_impl->dropped_accum += mon->sentpkts - received;
-                        m_impl->sent_accum += mon->sentpkts;
+                    m_impl->sent_total += mon->sentpkts;
+                    m_impl->recv_total += m_impl->pkts_since_monitor;
+
+                    // Only a cumulative shortfall is real loss; a deficit that
+                    // the next interval makes up was just a boundary straddle.
+                    const int64_t balance = static_cast<int64_t>(m_impl->sent_total) -
+                                            static_cast<int64_t>(m_impl->recv_total);
+                    const uint64_t lost = balance > 0 ? static_cast<uint64_t>(balance) : 0;
+                    if (lost > m_impl->reported_lost) {
                         auto now = std::chrono::steady_clock::now();
                         if (now - m_impl->last_drop_log_time >= std::chrono::seconds(1)) {
-                            fprintf(stderr, "[cbdev] dropped %u of %u packets\n",
-                                    m_impl->dropped_accum, m_impl->sent_accum);
-                            m_impl->dropped_accum = 0;
-                            m_impl->sent_accum = 0;
+                            fprintf(stderr, "[cbdev] dropped %llu of %llu packets (%.4f%%)\n",
+                                    static_cast<unsigned long long>(lost),
+                                    static_cast<unsigned long long>(m_impl->sent_total),
+                                    100.0 * static_cast<double>(lost) /
+                                        static_cast<double>(m_impl->sent_total));
+                            m_impl->reported_lost = lost;
                             m_impl->last_drop_log_time = now;
                         }
                     }

--- a/src/cbsdk/src/sdk_session.cpp
+++ b/src/cbsdk/src/sdk_session.cpp
@@ -273,12 +273,51 @@ struct SdkSession::Impl {
     struct ConfigCB     { CallbackHandle handle; uint16_t packet_type; ConfigCallback cb; };
     struct RunlevelCB   { CallbackHandle handle; RunlevelCallback cb; };
 
-    std::vector<PacketCB>     packet_callbacks;
-    std::vector<EventCB>      event_callbacks;
-    std::vector<GroupCB>       group_callbacks;
-    std::vector<GroupBatchCB>  group_batch_callbacks;
-    std::vector<ConfigCB>     config_callbacks;
-    std::vector<RunlevelCB>   runlevel_callbacks;
+    /// Copy-on-write list of callbacks.
+    ///
+    /// Registration is rare and dispatch is hot (30k packets/s/device), so the
+    /// list is immutable once published: a mutation builds a fresh vector and
+    /// swaps the pointer, and dispatch takes a shared_ptr copy — one atomic
+    /// increment — instead of deep-copying a vector of std::function (each copy
+    /// of which can allocate).
+    template<typename CB>
+    struct CallbackList {
+        using List = std::vector<CB>;
+        using Ptr = std::shared_ptr<const List>;
+
+        /// Snapshot for dispatch.  Never null.
+        Ptr get() const { return list; }
+
+        /// Append under the caller's lock.
+        void add(CB cb) {
+            auto next = std::make_shared<List>(*list);
+            next->push_back(std::move(cb));
+            list = std::move(next);
+        }
+
+        /// Remove by handle under the caller's lock.  No-op (and no
+        /// reallocation) when the handle isn't ours.
+        void remove(CallbackHandle handle) {
+            const auto it = std::find_if(list->begin(), list->end(),
+                [handle](const CB& cb) { return cb.handle == handle; });
+            if (it == list->end()) return;
+            auto next = std::make_shared<List>(*list);
+            next->erase(std::remove_if(next->begin(), next->end(),
+                [handle](const CB& cb) { return cb.handle == handle; }),
+                next->end());
+            list = std::move(next);
+        }
+
+    private:
+        Ptr list = std::make_shared<const List>();
+    };
+
+    CallbackList<PacketCB>     packet_callbacks;
+    CallbackList<EventCB>      event_callbacks;
+    CallbackList<GroupCB>      group_callbacks;
+    CallbackList<GroupBatchCB> group_batch_callbacks;
+    CallbackList<ConfigCB>     config_callbacks;
+    CallbackList<RunlevelCB>   runlevel_callbacks;
 
     /// Atomically update device_runlevel; fire registered callbacks if the
     /// value changed.  Called from the receive thread (STANDALONE) or the
@@ -286,12 +325,12 @@ struct SdkSession::Impl {
     void updateRunlevel(uint32_t new_runlevel) {
         const uint32_t prev = device_runlevel.exchange(new_runlevel, std::memory_order_acq_rel);
         if (prev == new_runlevel) return;
-        std::vector<RunlevelCB> snap;
+        decltype(runlevel_callbacks)::Ptr snap;
         {
             std::lock_guard<std::mutex> lock(user_callback_mutex);
-            snap = runlevel_callbacks;
+            snap = runlevel_callbacks.get();
         }
-        for (const auto& cb : snap) {
+        for (const auto& cb : *snap) {
             if (cb.cb) cb.cb(new_runlevel);
         }
     }
@@ -813,19 +852,19 @@ struct SdkSession::Impl {
         }
 
         // Phase 1: batch group callbacks (one invocation per group_id per batch)
-        std::vector<GroupBatchCB> snap_batch;
+        decltype(group_batch_callbacks)::Ptr snap_batch;
         {
             std::lock_guard<std::mutex> lock(user_callback_mutex);
-            snap_batch = group_batch_callbacks;
+            snap_batch = group_batch_callbacks.get();
         }
 
-        if (!snap_batch.empty()) {
+        if (!snap_batch->empty()) {
             // Temp buffers — sized for max batch (128 packets × 272 channels)
             // ~70KB on stack, well within typical thread stack limits.
             int16_t sample_buf[128 * cbNUM_ANALOG_CHANS];
             uint64_t ts_buf[128];
 
-            for (const auto& bcb : snap_batch) {
+            for (const auto& bcb : *snap_batch) {
                 size_t n = 0;
                 size_t n_channels = 0;
 
@@ -959,30 +998,33 @@ struct SdkSession::Impl {
 
     /// Dispatch a single packet to all matching typed callbacks.
     /// Called on the callback thread (off the queue).
-    /// Snapshots each callback vector under lock, then dispatches without lock (Phase 2, Fix 6).
+    /// Takes a shared_ptr snapshot of each callback list under lock, then
+    /// dispatches without the lock so user callbacks can take arbitrary time.
     void dispatchPacket(const cbPKT_GENERIC& pkt) {
         const uint16_t chid = pkt.cbpkt_header.chid;
 
-        // Snapshot callback vectors under lock (fast: just copies a few pointers+sizes)
-        std::vector<PacketCB> snap_packet;
-        std::vector<EventCB>  snap_event;
-        std::vector<GroupCB>  snap_group;
-        std::vector<ConfigCB> snap_config;
+        // Snapshot the callback lists under lock.  These are copy-on-write, so
+        // each snapshot is a refcount bump rather than a vector-of-std::function
+        // copy — this runs on every packet (~30k/s per device).
+        decltype(packet_callbacks)::Ptr snap_packet;
+        decltype(event_callbacks)::Ptr  snap_event;
+        decltype(group_callbacks)::Ptr  snap_group;
+        decltype(config_callbacks)::Ptr snap_config;
         {
             std::lock_guard<std::mutex> lock(user_callback_mutex);
-            snap_packet = packet_callbacks;
-            // Only snapshot the vectors we'll actually need for this packet type
+            snap_packet = packet_callbacks.get();
+            // Only snapshot the list we'll actually need for this packet type
             if (chid != 0 && !(chid & cbPKTCHAN_CONFIGURATION)) {
-                snap_event = event_callbacks;
+                snap_event = event_callbacks.get();
             } else if (chid == 0) {
-                snap_group = group_callbacks;
+                snap_group = group_callbacks.get();
             } else if (chid & cbPKTCHAN_CONFIGURATION) {
-                snap_config = config_callbacks;
+                snap_config = config_callbacks.get();
             }
         }
 
         // Dispatch without holding the lock — user callbacks can take arbitrary time
-        for (const auto& cb : snap_packet) {
+        for (const auto& cb : *snap_packet) {
             if (cb.cb) cb.cb(pkt);
         }
 
@@ -992,19 +1034,19 @@ struct SdkSession::Impl {
             if (channel_cache_valid && chid >= 1 && chid <= local_max_chans) {
                 pkt_chan_type = channel_type_cache[chid - 1];
             }
-            for (const auto& cb : snap_event) {
+            for (const auto& cb : *snap_event) {
                 if (cb.channel_type == ChannelType::ANY || cb.channel_type == pkt_chan_type) {
                     if (cb.cb) cb.cb(pkt);
                 }
             }
         } else if (chid == 0) {
-            for (const auto& cb : snap_group) {
+            for (const auto& cb : *snap_group) {
                 if (pkt.cbpkt_header.type == cb.group_id) {
                     if (cb.cb) cb.cb(reinterpret_cast<const cbPKT_GROUP&>(pkt));
                 }
             }
         } else if (chid & cbPKTCHAN_CONFIGURATION) {
-            for (const auto& cb : snap_config) {
+            for (const auto& cb : *snap_config) {
                 if (pkt.cbpkt_header.type == cb.packet_type) {
                     if (cb.cb) cb.cb(pkt);
                 }
@@ -1818,14 +1860,14 @@ bool SdkSession::isRunning() const {
 CallbackHandle SdkSession::registerPacketCallback(PacketCallback callback) const {
     std::lock_guard<std::mutex> lock(m_impl->user_callback_mutex);
     const auto handle = m_impl->next_callback_handle++;
-    m_impl->packet_callbacks.push_back({handle, std::move(callback)});
+    m_impl->packet_callbacks.add({handle, std::move(callback)});
     return handle;
 }
 
 CallbackHandle SdkSession::registerEventCallback(const ChannelType channel_type, EventCallback callback) const {
     std::lock_guard<std::mutex> lock(m_impl->user_callback_mutex);
     const auto handle = m_impl->next_callback_handle++;
-    m_impl->event_callbacks.push_back({handle, channel_type, std::move(callback)});
+    m_impl->event_callbacks.add({handle, channel_type, std::move(callback)});
     return handle;
 }
 
@@ -1833,7 +1875,7 @@ CallbackHandle SdkSession::registerGroupCallback(const SampleRate rate, GroupCal
     const uint8_t group_id = static_cast<uint8_t>(rate);
     std::lock_guard<std::mutex> lock(m_impl->user_callback_mutex);
     const auto handle = m_impl->next_callback_handle++;
-    m_impl->group_callbacks.push_back({handle, group_id, std::move(callback)});
+    m_impl->group_callbacks.add({handle, group_id, std::move(callback)});
     return handle;
 }
 
@@ -1841,37 +1883,32 @@ CallbackHandle SdkSession::registerGroupBatchCallback(const SampleRate rate, Gro
     const uint8_t group_id = static_cast<uint8_t>(rate);
     std::lock_guard<std::mutex> lock(m_impl->user_callback_mutex);
     const auto handle = m_impl->next_callback_handle++;
-    m_impl->group_batch_callbacks.push_back({handle, group_id, std::move(callback)});
+    m_impl->group_batch_callbacks.add({handle, group_id, std::move(callback)});
     return handle;
 }
 
 CallbackHandle SdkSession::registerConfigCallback(const uint16_t packet_type, ConfigCallback callback) const {
     std::lock_guard<std::mutex> lock(m_impl->user_callback_mutex);
     const auto handle = m_impl->next_callback_handle++;
-    m_impl->config_callbacks.push_back({handle, packet_type, std::move(callback)});
+    m_impl->config_callbacks.add({handle, packet_type, std::move(callback)});
     return handle;
 }
 
 CallbackHandle SdkSession::registerRunlevelChangeCallback(RunlevelCallback callback) const {
     std::lock_guard<std::mutex> lock(m_impl->user_callback_mutex);
     const auto handle = m_impl->next_callback_handle++;
-    m_impl->runlevel_callbacks.push_back({handle, std::move(callback)});
+    m_impl->runlevel_callbacks.add({handle, std::move(callback)});
     return handle;
 }
 
 void SdkSession::unregisterCallback(CallbackHandle handle) const {
     std::lock_guard<std::mutex> lock(m_impl->user_callback_mutex);
-    auto erase_by_handle = [handle](auto& vec) {
-        vec.erase(std::remove_if(vec.begin(), vec.end(),
-            [handle](const auto& cb) { return cb.handle == handle; }),
-            vec.end());
-    };
-    erase_by_handle(m_impl->packet_callbacks);
-    erase_by_handle(m_impl->event_callbacks);
-    erase_by_handle(m_impl->group_callbacks);
-    erase_by_handle(m_impl->group_batch_callbacks);
-    erase_by_handle(m_impl->config_callbacks);
-    erase_by_handle(m_impl->runlevel_callbacks);
+    m_impl->packet_callbacks.remove(handle);
+    m_impl->event_callbacks.remove(handle);
+    m_impl->group_callbacks.remove(handle);
+    m_impl->group_batch_callbacks.remove(handle);
+    m_impl->config_callbacks.remove(handle);
+    m_impl->runlevel_callbacks.remove(handle);
 }
 
 void SdkSession::setErrorCallback(ErrorCallback callback) {

--- a/src/cbsdk/src/sdk_session.cpp
+++ b/src/cbsdk/src/sdk_session.cpp
@@ -165,6 +165,9 @@ struct PeerClockReader {
 
 namespace cbsdk {
 
+/// Defined below; used by SdkSession::Impl to name peer devices' segments.
+static std::string getNativeSegmentName(DeviceType type, const std::string& segment);
+
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 // Channel type classification helper (capability-based)
 ///////////////////////////////////////////////////////////////////////////////////////////////////
@@ -527,9 +530,20 @@ struct SdkSession::Impl {
     struct PeerHub {
         std::string segment;
         std::unique_ptr<PeerClockReader> reader;
+        // Peers that are not running have no segment to open, and shm_open on a
+        // missing name is a syscall that always fails.  Space the retries so an
+        // absent peer costs almost nothing.
+        std::chrono::steady_clock::time_point next_open_attempt{};
     };
     std::vector<PeerHub> peer_hubs;
     bool peer_hubs_init = false;
+
+    /// How often clock maintenance (probe, cross-device consensus, publication)
+    /// runs.  The estimate it produces cannot change faster than the probes
+    /// that feed it, so running it per datagram only burns receive-thread time.
+    static constexpr auto kClockMaintenanceInterval = std::chrono::milliseconds(100);
+    /// Retry interval for opening a peer's config segment (see PeerHub).
+    static constexpr auto kPeerReopenInterval = std::chrono::seconds(2);
     struct PendingClockProbe {
         std::chrono::steady_clock::time_point t1_local;
         bool active = false;
@@ -839,6 +853,108 @@ struct SdkSession::Impl {
         for (size_t i = 0; i < count; i++) {
             dispatchPacket(packets[i]);
         }
+    }
+
+    /// @brief Re-derive this device's clock offset from the cross-device
+    ///        consensus and publish the result to shared memory.
+    ///
+    /// Cross-device clock consensus.  Devices that share one PTP clock should
+    /// report the same device->host offset.  Each device publishes its own
+    /// (independent) estimate; here we combine this device's estimate with
+    /// every peer's and use the median, so a transiently-biased device is
+    /// outvoted instead of skewing time conversion.  All participants read the
+    /// same set of published estimates and therefore converge on the same
+    /// median.  Consensus needs >=3 participants to reject one outlier; with
+    /// fewer, an NSP still borrows a HUB's offset (its own probes are
+    /// unreliable) and other device types keep their own estimate.
+    ///
+    /// Only Gemini devices (NSP + HUBs) share one PTP clock.  Non-Gemini
+    /// devices (legacy NSP, nPlay, custom) have independent clocks and must not
+    /// be averaged together, so they skip consensus/borrow entirely.
+    ///
+    /// @note Runs on the device receive thread, on the cadence set by
+    ///       kClockMaintenanceInterval — never per datagram.  It performs
+    ///       syscalls (shm_open, kill) and shared-memory writes, all of which
+    ///       would otherwise stall the return to recvfrom().
+    void updateClockConsensus(std::chrono::steady_clock::time_point now) {
+        const DeviceType self_type = config.device_type;
+        const bool shares_ptp_clock =
+            self_type == DeviceType::NSP  ||
+            self_type == DeviceType::HUB1 || self_type == DeviceType::HUB2 ||
+            self_type == DeviceType::HUB3;
+        if (shares_ptp_clock) {
+            if (!peer_hubs_init) {
+                peer_hubs_init = true;
+                for (auto dt : {DeviceType::NSP, DeviceType::HUB1,
+                                DeviceType::HUB2, DeviceType::HUB3}) {
+                    if (dt == config.device_type)
+                        continue;  // skip self
+                    peer_hubs.push_back(
+                        {getNativeSegmentName(dt, "config"),
+                         std::make_unique<PeerClockReader>()});
+                }
+            }
+
+            // Collect peer votes; track the lowest-uncertainty peer for
+            // the <3-participant fallback.  At most four devices share a
+            // clock, so the votes never need the heap.
+            std::array<int64_t, 4> votes{};
+            size_t n_votes = 0;
+            std::optional<int64_t> best_peer_offset;
+            std::optional<int64_t> best_peer_uncert;
+            int64_t best_peer_uncert_val = INT64_MAX;
+            for (auto& ph : peer_hubs) {
+                if (!ph.reader->isOpen()) {
+                    // A peer that isn't running has no segment to open; back
+                    // off so the failing shm_open isn't retried every cycle.
+                    if (now < ph.next_open_attempt)
+                        continue;
+                    if (!ph.reader->tryOpen(ph.segment)) {
+                        ph.next_open_attempt = now + kPeerReopenInterval;
+                        continue;
+                    }
+                }
+                // Vote on the peer's own (pre-consensus) estimate so the
+                // median can track real common-mode drift.
+                auto offset = ph.reader->getRawOffsetNs();
+                if (!offset)
+                    continue;
+                if (n_votes < votes.size())
+                    votes[n_votes++] = *offset;
+                auto uncert = ph.reader->getClockUncertaintyNs();
+                const int64_t uncert_val = uncert ? *uncert : INT64_MAX;
+                if (!best_peer_offset || uncert_val < best_peer_uncert_val) {
+                    best_peer_offset = offset;
+                    best_peer_uncert = uncert;
+                    best_peer_uncert_val = uncert_val;
+                }
+            }
+            // This device's own independent vote.
+            if (auto own = device_session->getInternalOffsetNs()) {
+                if (n_votes < votes.size())
+                    votes[n_votes++] = *own;
+            }
+
+            if (n_votes >= 3) {
+                std::sort(votes.begin(), votes.begin() + n_votes);
+                const int64_t median = votes[n_votes / 2];
+                device_session->setExternalClockOffset(median);
+            } else if (config.device_type == DeviceType::NSP && best_peer_offset) {
+                // Too few for consensus: a Gemini NSP still borrows a HUB.
+                device_session->setExternalClockOffset(best_peer_offset, best_peer_uncert);
+            } else {
+                device_session->setExternalClockOffset(std::nullopt);
+            }
+        }
+
+        // Publish two offsets: the committed (post-consensus) value in
+        // clock_offset_ns for CLIENT-mode readers, and this device's own
+        // (pre-consensus) estimate in clock_raw_offset_ns for peers to vote on.
+        const auto uncertainty = device_session->getUncertaintyNs().value_or(0);
+        if (auto committed = device_session->getOffsetNs())
+            shmem_session->setClockSync(*committed, uncertainty);
+        if (auto internal = device_session->getInternalOffsetNs())
+            shmem_session->setClockRawOffset(*internal);
     }
 
     /// Dispatch a single packet to all matching typed callbacks.
@@ -1311,96 +1427,18 @@ Result<void> SdkSession::start() {
                     return;
                 }
 
-                // Periodic clock sync probing
-                auto now = std::chrono::steady_clock::now();
-                if (now - impl->last_clock_probe_time > std::chrono::milliseconds(100)) {
-                    impl->device_session->sendClockProbe();
+                // Clock maintenance runs on a fixed cadence, not once per
+                // datagram.  This callback is on the UDP receive thread, which
+                // has to get back to recvfrom() before the socket buffer fills;
+                // at 30 kHz, doing the work below per datagram cost ~90k
+                // shm_open and ~30k kill() syscalls per second per device.
+                // Nothing here can produce a new answer faster than the probe
+                // interval that feeds it.
+                const auto now = std::chrono::steady_clock::now();
+                if (now - impl->last_clock_probe_time > Impl::kClockMaintenanceInterval) {
                     impl->last_clock_probe_time = now;
-                }
-
-                // Cross-device clock consensus.  Devices that share one PTP
-                // clock should report the same device->host offset.  Each device
-                // publishes its own (independent) estimate; here we combine this
-                // device's estimate with every peer's and use the median, so a
-                // transiently-biased device is outvoted instead of skewing time
-                // conversion.  All participants read the same set of published
-                // estimates and therefore converge on the same median.
-                // Consensus needs >=3 participants to reject one outlier; with
-                // fewer, an NSP still borrows a HUB's offset (its own probes are
-                // unreliable) and other device types keep their own estimate.
-                //
-                // Only Gemini devices (NSP + HUBs) share one PTP clock.
-                // Non-Gemini devices (legacy NSP, nPlay, custom) have
-                // independent clocks and must not be averaged together, so they
-                // skip consensus/borrow entirely.
-                const DeviceType self_type = impl->config.device_type;
-                const bool shares_ptp_clock =
-                    self_type == DeviceType::NSP  ||
-                    self_type == DeviceType::HUB1 || self_type == DeviceType::HUB2 ||
-                    self_type == DeviceType::HUB3;
-                if (shares_ptp_clock) {
-                    if (!impl->peer_hubs_init) {
-                        impl->peer_hubs_init = true;
-                        for (auto dt : {DeviceType::NSP, DeviceType::HUB1,
-                                        DeviceType::HUB2, DeviceType::HUB3}) {
-                            if (dt == impl->config.device_type)
-                                continue;  // skip self
-                            impl->peer_hubs.push_back(
-                                {getNativeSegmentName(dt, "config"),
-                                 std::make_unique<PeerClockReader>()});
-                        }
-                    }
-
-                    // Collect peer votes; track the lowest-uncertainty peer for
-                    // the <3-participant fallback.
-                    std::vector<int64_t> votes;
-                    std::optional<int64_t> best_peer_offset;
-                    std::optional<int64_t> best_peer_uncert;
-                    int64_t best_peer_uncert_val = INT64_MAX;
-                    for (auto& ph : impl->peer_hubs) {
-                        if (!ph.reader->isOpen())
-                            ph.reader->tryOpen(ph.segment);
-                        // Vote on the peer's own (pre-consensus) estimate so the
-                        // median can track real common-mode drift.
-                        auto offset = ph.reader->getRawOffsetNs();
-                        if (!offset)
-                            continue;
-                        votes.push_back(*offset);
-                        auto uncert = ph.reader->getClockUncertaintyNs();
-                        const int64_t uncert_val = uncert ? *uncert : INT64_MAX;
-                        if (!best_peer_offset || uncert_val < best_peer_uncert_val) {
-                            best_peer_offset = offset;
-                            best_peer_uncert = uncert;
-                            best_peer_uncert_val = uncert_val;
-                        }
-                    }
-                    // This device's own independent vote.
-                    if (auto own = impl->device_session->getInternalOffsetNs())
-                        votes.push_back(*own);
-
-                    if (votes.size() >= 3) {
-                        std::sort(votes.begin(), votes.end());
-                        const int64_t median = votes[votes.size() / 2];
-                        impl->device_session->setExternalClockOffset(median);
-                    } else if (impl->config.device_type == DeviceType::NSP &&
-                               best_peer_offset) {
-                        // Too few for consensus: a Gemini NSP still borrows a HUB.
-                        impl->device_session->setExternalClockOffset(best_peer_offset, best_peer_uncert);
-                    } else {
-                        impl->device_session->setExternalClockOffset(std::nullopt);
-                    }
-                }
-
-                // Publish two offsets: the committed (post-consensus) value in
-                // clock_offset_ns for CLIENT-mode readers, and this device's own
-                // (pre-consensus) estimate in clock_raw_offset_ns for peers to
-                // vote on.
-                {
-                    auto uncertainty = impl->device_session->getUncertaintyNs().value_or(0);
-                    if (auto committed = impl->device_session->getOffsetNs())
-                        impl->shmem_session->setClockSync(*committed, uncertainty);
-                    if (auto internal = impl->device_session->getInternalOffsetNs())
-                        impl->shmem_session->setClockRawOffset(*internal);
+                    impl->device_session->sendClockProbe();
+                    impl->updateClockConsensus(now);
                 }
 
                 // Signal CLIENT processes that new data is available

--- a/tests/unit/test_sdk_session.cpp
+++ b/tests/unit/test_sdk_session.cpp
@@ -176,20 +176,29 @@ TEST_F(SdkSessionTest, SetCallbacks) {
 
     auto& session = result.value();
 
-    bool packet_callback_invoked = false;
-    bool error_callback_invoked = false;
+    // create() has already started the session, and with a real device packets
+    // may already be flowing — so this can only assert the registration
+    // contract, not that the callbacks have yet to fire.  (An earlier version
+    // asserted the packet callback had NOT been invoked, which is a race
+    // against a live HUB1 streaming at 30 kHz.)
+    std::atomic<int> packets{0};
+    std::atomic<int> errors{0};
 
-    session.registerPacketCallback([&packet_callback_invoked](const cbPKT_GENERIC& pkt) {
-        packet_callback_invoked = true;
-    });
+    const auto packet_handle = session.registerPacketCallback(
+        [&packets](const cbPKT_GENERIC&) { packets.fetch_add(1); });
+    const auto event_handle = session.registerEventCallback(
+        ChannelType::ANY, [](const cbPKT_GENERIC&) {});
 
-    session.setErrorCallback([&error_callback_invoked](const std::string& error) {
-        error_callback_invoked = true;
-    });
+    session.setErrorCallback([&errors](const std::string&) { errors.fetch_add(1); });
 
-    // Callbacks set successfully
-    EXPECT_FALSE(packet_callback_invoked);
-    EXPECT_FALSE(error_callback_invoked);
+    // Registration yields distinct, usable handles...
+    EXPECT_NE(packet_handle, 0u);
+    EXPECT_NE(event_handle, 0u);
+    EXPECT_NE(packet_handle, event_handle);
+
+    // ...and unregistering them is accepted.
+    session.unregisterCallback(packet_handle);
+    session.unregisterCallback(event_handle);
 }
 
 TEST_F(SdkSessionTest, ReceivePackets_FromDevice) {

--- a/tools/rx_bench/CMakeLists.txt
+++ b/tools/rx_bench/CMakeLists.txt
@@ -1,0 +1,8 @@
+# rx_bench - STANDALONE UDP reception benchmark (packet-loss attribution)
+add_executable(rx_bench rx_bench.cpp)
+target_link_libraries(rx_bench PRIVATE cbsdk cbdev cbproto)
+target_include_directories(rx_bench PRIVATE
+    ${PROJECT_SOURCE_DIR}/src/cbsdk/include
+    ${PROJECT_SOURCE_DIR}/src/cbdev/include
+    ${PROJECT_SOURCE_DIR}/src/cbproto/include
+    ${PROJECT_SOURCE_DIR}/src/cbutil/include)

--- a/tools/rx_bench/rx_bench.cpp
+++ b/tools/rx_bench/rx_bench.cpp
@@ -1,0 +1,327 @@
+///////////////////////////////////////////////////////////////////////////////////////////////////
+/// @file   rx_bench.cpp
+/// @brief  STANDALONE UDP reception benchmark.
+///
+/// Streams continuous sample-group data from one or more devices and attributes
+/// packet loss to a layer, using two independent measures:
+///
+///   * firmware reconciliation — every cbPKT_SYSPROTOCOLMONITOR reports how
+///     many packets the device sent; summing whole monitor-to-monitor intervals
+///     and comparing against what arrived measures loss on the wire and in the
+///     kernel.  Per-interval deficits and surpluses are reported separately:
+///     a packet that straddles a monitor boundary shows up as a deficit in one
+///     interval and a matching surplus in the next, which is NOT loss.
+///   * timestamp contiguity — gaps in the group-packet timestamp sequence.
+///
+///   * callback-queue loss — SdkStats::packets_dropped, i.e. loss inside the
+///     SDK rather than below it.
+///
+/// A second instance run against a device that already has an owner attaches in
+/// CLIENT mode, which exercises the shared-memory ring instead of the socket.
+///
+/// Usage:
+///   rx_bench [--device HUB1[,HUB2,...]] [--seconds 30] [--group 6]
+///
+///////////////////////////////////////////////////////////////////////////////////////////////////
+
+#include <cbsdk/sdk_session.h>
+
+#include <algorithm>
+#include <atomic>
+#include <chrono>
+#include <cstring>
+#include <iomanip>
+#include <iostream>
+#include <memory>
+#include <optional>
+#include <string>
+#include <thread>
+#include <vector>
+
+namespace {
+
+/// Records group-packet timestamps during the measurement window and derives
+/// the loss figures afterwards.  Post-hoc analysis (rather than streaming
+/// inference) keeps the period estimate robust: it is the median over the whole
+/// run, not over whatever the first few dozen packets happened to look like.
+struct GapTracker {
+    std::vector<uint64_t> times;   // appended by the callback thread only
+
+    // Results, filled by analyze()
+    uint64_t period = 0;
+    uint64_t gap_events = 0;
+    uint64_t missing = 0;
+    uint64_t backward = 0;
+    uint64_t worst_gap = 0;
+
+    void reserveFor(double seconds) { times.reserve(static_cast<size_t>(seconds * 31000.0) + 1024); }
+
+    void analyze() {
+        if (times.size() < 3) return;
+
+        std::vector<int64_t> deltas;
+        deltas.reserve(times.size() - 1);
+        for (size_t i = 1; i < times.size(); ++i) {
+            deltas.push_back(static_cast<int64_t>(times[i]) - static_cast<int64_t>(times[i - 1]));
+        }
+
+        std::vector<int64_t> sorted = deltas;
+        std::sort(sorted.begin(), sorted.end());
+        period = static_cast<uint64_t>(std::max<int64_t>(sorted[sorted.size() / 2], 1));
+
+        // Integer tick->ns conversion makes 30 kHz deltas alternate 33333/33334,
+        // so anything within one period plus a few ns of jitter is contiguous.
+        const int64_t p = static_cast<int64_t>(period);
+        for (const int64_t d : deltas) {
+            if (d <= 0) { ++backward; continue; }
+            if (d <= p + 2) continue;
+            // Round to the nearest whole number of periods.
+            const int64_t n = (d + p / 2) / p;
+            if (n <= 1) continue;   // jitter, not a dropped packet
+            ++gap_events;
+            missing += static_cast<uint64_t>(n - 1);
+            worst_gap = std::max<uint64_t>(worst_gap, static_cast<uint64_t>(d));
+        }
+    }
+};
+
+struct DeviceRun {
+    std::string name;
+    cbsdk::DeviceType type;
+    std::unique_ptr<cbsdk::SdkSession> session;
+    GapTracker gaps;
+    std::atomic<bool> measuring{false};
+    std::atomic<uint64_t> group_packets{0};
+    std::atomic<uint64_t> overflow_errors{0};
+
+    // Ground truth from the device: every cbPKT_SYSPROTOCOLMONITOR reports how
+    // many packets the firmware sent since the previous one.  Summing those and
+    // comparing against what we actually received measures loss on the wire and
+    // in the kernel, independent of any timestamp reasoning.
+    std::atomic<uint64_t> device_sent{0};
+    std::atomic<uint64_t> all_packets{0};
+    std::atomic<uint64_t> monitors{0};
+    // Callback-thread-only state.  Kept here rather than in a `mutable` lambda
+    // capture: SdkSession stores callbacks as std::function and dispatches from
+    // a snapshot, so per-invocation mutations to a capture are not guaranteed to
+    // persist.
+    uint64_t since_monitor = 0;
+    bool armed = false;
+    std::vector<int64_t> interval_deltas;   // received - sent, per monitor interval
+
+    std::optional<int64_t> clock_offset_first;
+    std::optional<int64_t> clock_offset_ns;
+    std::optional<int64_t> clock_uncertainty_ns;
+};
+
+cbsdk::DeviceType parseDevice(const std::string& s, bool& ok) {
+    ok = true;
+    if (s == "NSP")        return cbsdk::DeviceType::NSP;
+    if (s == "HUB1")       return cbsdk::DeviceType::HUB1;
+    if (s == "HUB2")       return cbsdk::DeviceType::HUB2;
+    if (s == "HUB3")       return cbsdk::DeviceType::HUB3;
+    if (s == "LEGACY_NSP") return cbsdk::DeviceType::LEGACY_NSP;
+    if (s == "NPLAY")      return cbsdk::DeviceType::NPLAY;
+    ok = false;
+    return cbsdk::DeviceType::HUB1;
+}
+
+std::vector<std::string> split(const std::string& s, char sep) {
+    std::vector<std::string> out;
+    size_t start = 0;
+    while (true) {
+        const size_t pos = s.find(sep, start);
+        out.push_back(s.substr(start, pos - start));
+        if (pos == std::string::npos) break;
+        start = pos + 1;
+    }
+    return out;
+}
+
+}  // namespace
+
+int main(int argc, char** argv) {
+    std::string devices_arg = "HUB1";
+    double seconds = 20.0;
+    int group = 6;
+
+    for (int i = 1; i < argc; ++i) {
+        const std::string a = argv[i];
+        auto next = [&]() -> std::string { return (i + 1 < argc) ? argv[++i] : std::string(); };
+        if (a == "--device" || a == "-d")       devices_arg = next();
+        else if (a == "--seconds" || a == "-s") seconds = std::stod(next());
+        else if (a == "--group" || a == "-g")   group = std::stoi(next());
+        else {
+            std::cerr << "Usage: rx_bench [--device HUB1,HUB2] [--seconds N] [--group 6]\n";
+            return 2;
+        }
+    }
+
+    std::vector<std::unique_ptr<DeviceRun>> runs;
+    for (const auto& name : split(devices_arg, ',')) {
+        bool ok = false;
+        const auto type = parseDevice(name, ok);
+        if (!ok) {
+            std::cerr << "Unknown device: " << name << "\n";
+            return 2;
+        }
+        auto run = std::make_unique<DeviceRun>();
+        run->name = name;
+        run->type = type;
+        runs.push_back(std::move(run));
+    }
+
+    // --- open sessions -------------------------------------------------------
+    for (auto& run : runs) {
+        cbsdk::SdkConfig cfg;
+        cfg.device_type = run->type;
+        auto res = cbsdk::SdkSession::create(cfg);
+        if (res.isError()) {
+            std::cerr << run->name << ": create failed: " << res.error() << "\n";
+            return 1;
+        }
+        run->session = std::make_unique<cbsdk::SdkSession>(std::move(res.value()));
+
+        auto* raw = run.get();
+        raw->session->setErrorCallback([raw](const std::string&) {
+            raw->overflow_errors.fetch_add(1, std::memory_order_relaxed);
+        });
+        raw->session->registerGroupCallback(
+            static_cast<cbsdk::SampleRate>(group),
+            [raw](const cbPKT_GROUP& pkt) {
+                if (!raw->measuring.load(std::memory_order_relaxed)) return;
+                raw->group_packets.fetch_add(1, std::memory_order_relaxed);
+                raw->gaps.times.push_back(pkt.cbpkt_header.time);
+            });
+        // Catch-all: counts everything and reconciles against the firmware's own
+        // sent-packet count at each SYSPROTOCOLMONITOR boundary.  Accumulating
+        // only whole monitor-to-monitor intervals keeps the comparison exact —
+        // a partial interval at either end of the window would otherwise bias
+        // the result by up to one full interval's worth of packets.
+        raw->session->registerPacketCallback([raw](const cbPKT_GENERIC& pkt) {
+            if (!raw->measuring.load(std::memory_order_relaxed)) {
+                raw->armed = false;
+                return;
+            }
+            ++raw->since_monitor;
+            if (pkt.cbpkt_header.type != cbPKTTYPE_SYSPROTOCOLMONITOR) return;
+
+            const auto* mon = reinterpret_cast<const cbPKT_SYSPROTOCOLMONITOR*>(&pkt);
+            if (raw->armed) {
+                raw->monitors.fetch_add(1, std::memory_order_relaxed);
+                raw->device_sent.fetch_add(mon->sentpkts, std::memory_order_relaxed);
+                raw->all_packets.fetch_add(raw->since_monitor, std::memory_order_relaxed);
+                raw->interval_deltas.push_back(static_cast<int64_t>(raw->since_monitor) -
+                                               static_cast<int64_t>(mon->sentpkts));
+            }
+            raw->armed = true;
+            raw->since_monitor = 0;
+        });
+        run->gaps.reserveFor(seconds + 2.0);
+        // SdkSession::create() already starts the session (handshake + threads).
+        std::cout << run->name << ": session created and running\n";
+    }
+
+    // Let the handshake/config dump settle before measuring.
+    std::this_thread::sleep_for(std::chrono::seconds(2));
+    for (auto& run : runs) {
+        run->session->resetStats();
+        run->measuring.store(true, std::memory_order_relaxed);
+    }
+
+    for (auto& run : runs) run->clock_offset_first = run->session->getClockOffsetNs();
+
+    const auto t0 = std::chrono::steady_clock::now();
+    std::this_thread::sleep_for(std::chrono::duration<double>(seconds));
+    const auto t1 = std::chrono::steady_clock::now();
+    const double elapsed = std::chrono::duration<double>(t1 - t0).count();
+
+    for (auto& run : runs) run->measuring.store(false, std::memory_order_relaxed);
+    for (auto& run : runs) {
+        run->clock_offset_ns = run->session->getClockOffsetNs();
+        run->clock_uncertainty_ns = run->session->getClockUncertaintyNs();
+    }
+    for (auto& run : runs) run->session->stop();
+    for (auto& run : runs) run->gaps.analyze();
+
+    // --- report --------------------------------------------------------------
+    std::cout << "\n================ rx_bench (" << std::fixed << std::setprecision(2)
+              << elapsed << " s) ================\n";
+    int exit_code = 0;
+    for (auto& run : runs) {
+        const auto st = run->session->getStats();
+        const auto& g = run->gaps;
+        const double rate = static_cast<double>(st.packets_received_from_device) / elapsed;
+
+        std::cout << "\n--- " << run->name
+                  << (run->session->isStandalone() ? " [STANDALONE] ---\n" : " [CLIENT] ---\n");
+        if (!run->session->isStandalone()) {
+            std::cout << "  shmem overruns:   " << st.shmem_overruns << "\n";
+            std::cout << "  producer count:   " << st.packets_produced << "\n";
+        }
+        std::cout << "  rx from device:   " << st.packets_received_from_device
+                  << "  (" << std::setprecision(1) << rate << " pkt/s)\n";
+        std::cout << "  stored to shmem:  " << st.packets_stored_to_shmem << "\n";
+        std::cout << "  queued:           " << st.packets_queued_for_callback << "\n";
+        std::cout << "  delivered:        " << st.packets_delivered_to_callback << "\n";
+        std::cout << "  QUEUE DROPS:      " << st.packets_dropped << "\n";
+        std::cout << "  queue peak depth: " << st.queue_max_depth << "\n";
+        std::cout << "  shmem errors:     " << st.shmem_store_errors << "\n";
+        std::cout << "  recv errors:      " << st.receive_errors << "\n";
+        const uint64_t received = g.times.size();
+        std::cout << "  group " << group << " packets:  " << received
+                  << "  (period " << g.period << " ns)\n";
+        std::cout << "  GAP EVENTS:       " << g.gap_events << "\n";
+        std::cout << "  MISSING PACKETS:  " << g.missing;
+        if (received + g.missing > 0) {
+            std::cout << "  (" << std::setprecision(4)
+                      << (100.0 * static_cast<double>(g.missing) /
+                          static_cast<double>(received + g.missing))
+                      << " %)";
+        }
+        std::cout << "\n";
+        std::cout << "  worst gap:        " << g.worst_gap << " ns\n";
+        std::cout << "  backward ts:      " << g.backward << "\n";
+
+        const uint64_t sent = run->device_sent.load();
+        const uint64_t got = run->all_packets.load();
+        std::cout << "  -- firmware reconciliation (" << run->monitors.load()
+                  << " monitor intervals) --\n";
+        std::cout << "  device sent:      " << sent << "\n";
+        std::cout << "  we received:      " << got << "\n";
+        if (sent > 0) {
+            const int64_t lost = static_cast<int64_t>(sent) - static_cast<int64_t>(got);
+            std::cout << "  WIRE LOSS:        " << lost << "  (" << std::setprecision(4)
+                      << (100.0 * static_cast<double>(lost) / static_cast<double>(sent))
+                      << " %)\n";
+            if (lost > 0) exit_code = 1;
+        }
+        // Per-interval breakdown.  A real loss shows up as a persistent
+        // deficit; packets merely straddling a monitor boundary show up as a
+        // deficit in one interval and a matching surplus in the next.
+        {
+            int64_t deficit = 0, surplus = 0, worst = 0;
+            size_t n_short = 0, n_over = 0;
+            for (const int64_t d : run->interval_deltas) {
+                if (d < 0) { deficit += -d; ++n_short; worst = std::min(worst, d); }
+                else if (d > 0) { surplus += d; ++n_over; }
+            }
+            std::cout << "  intervals short:  " << n_short << " (total " << deficit
+                      << ", worst " << worst << ")\n";
+            std::cout << "  intervals over:   " << n_over << " (total " << surplus << ")\n";
+        }
+        // Clock sync health.  Reported so a change to the clock-maintenance
+        // cadence can be checked for drift or cross-device disagreement.
+        if (auto off = run->clock_offset_ns) {
+            std::cout << "  clock offset:     " << *off << " ns";
+            if (auto u = run->clock_uncertainty_ns) std::cout << "  (uncertainty " << *u << " ns)";
+            std::cout << "\n";
+            std::cout << "  offset drift:     " << (*off - run->clock_offset_first.value_or(*off))
+                      << " ns over the window\n";
+        }
+
+        if (g.missing > 0 || st.packets_dropped > 0) exit_code = 1;
+    }
+    std::cout << "\n";
+    return exit_code;
+}


### PR DESCRIPTION
Investigating a reported increase in dropped packets. The headline is that there was no increase — but the receive path did have real waste in it, and the drop detector was lying.

## The reported drops were not real

`[cbdev] dropped N of M packets` compared the device's `cbPKT_SYSPROTOCOLMONITOR.sentpkts` against our own count **one interval at a time**, and logged every shortfall. That is not a loss measurement. A packet sent just before a monitor packet can be reassembled just after it, so it lands in the next interval — a deficit in one, a matching surplus in the next. Only deficits were ever examined.

Measured on a Gemini HUB2 at 128 ch SR_RAW over 5.4M packets:

| | short intervals | over intervals | net |
|---|---|---|---|
| HUB2 | 76 (728 packets) | 38 (729 packets) | **−1** |
| HUB1 (256 ch) | 0 | 0 | 0 |

Zero real loss, yet the old detector fired roughly once a second indefinitely. HUB1 doesn't straddle at all, which made the noise look device-specific and credible.

The detector now tracks a running sent/received balance. Straddled packets cancel on the next interval; genuine loss does not. The same setup now reports 36 lost out of 3.6M — all from the config dump at startup — then falls silent.

## PR #190 is not implicated

A/B against the #190 merge base (`b10b0a4`) on live HUB1 + HUB2 at 256/128 ch SR_RAW: identical CPU (user 0.79 s, sys 2.80 s per 42 s) and identical loss. No throughput regression to bisect.

One trap for anyone re-measuring: HUB2's ~10 ms clock uncertainty (vs HUB1's ~250 µs) comes from `d61deeb` "Charge only unexplained spread to probe uncertainty", which landed **after** the #190 base. Baselining clock sync against that base makes it look like a regression when it isn't.

## What was actually slow

Profiling the receive path found the datagram-complete callback running the entire cross-device clock consensus on the UDP receive thread, once per datagram (~30 kHz). Only the probe was rate-limited. With no NSP or HUB3 present, that was ~90,000 *failing* `shm_open` calls per second per device, plus a `kill(2)` per live peer and a heap allocation per datagram — all on the thread that has to get back to `recvfrom()`.

Clock maintenance now runs on the 100 ms cadence the probes already used; nothing there can produce a new answer faster than the probes feeding it. Absent peers back off. Votes use a fixed array.

Separately, `dispatchPacket` deep-copied up to four `vector<std::function>` per packet (the comment claimed it "just copies a few pointers+sizes"). Those are now copy-on-write, so a snapshot is a refcount bump.

| metric (live HUB1 + HUB2, SR_RAW) | before | after |
|---|---|---|
| `shm_open` profile samples | 34 | **0** |
| `kill` profile samples | 14 | 1 |
| `dispatchBatch` samples | 46 | 14 |
| receive-thread non-blocked time | 43 | 10 |
| user CPU / 30 s | 0.81 s | **0.63 s** |

## Compatibility

No wire format, shared-memory layout, or Central-adapter changes. `signalData()` still fires per datagram, so CLIENT readers wake exactly as before; only the clock *publication* moves to 10 Hz, which is the rate the underlying estimate updates anyway.

Verified with a live CLIENT attached to a STANDALONE owner on the same segment: zero ring overruns, zero missing packets, full 30 kHz, and the client's offset tracked the owner's to within 54 µs against a 256 µs uncertainty.

## New tool

`tools/rx_bench` attributes packet loss to a layer using two independent measures — firmware reconciliation over whole monitor intervals (reporting deficit and surplus separately, so straddling can't be mistaken for loss) and group-timestamp contiguity — plus SDK queue drops and clock health. Run a second instance against the same device to exercise the CLIENT-mode shmem ring.

It earned its keep mid-review: it caught a genuine one-off 1.3% loss burst on HUB1, with both independent measures agreeing (7507 missing by timestamps, 7529 by firmware). Not reproducible in five subsequent attempts of the same sequence, so environmental rather than code — but it's the kind of event the old detector buried in noise.

## Testing

- 396/396 unit, 94/94 integration against live HUB1 + HUB2 (2 skipped: need an NSP / nPlay).
- 3-minute soak, both hubs: 5.42M packets each, 0 missing, 0 queue drops, 0 shmem errors.

One test changed: `SdkSessionTest.SetCallbacks` asserted a packet callback had *not* fired, which is a race against a live HUB1 at 30 kHz rather than an invariant. It passed only because dispatch was slow, and began failing intermittently once dispatch got faster. It now asserts the registration contract; `ReceivePackets_FromDevice` already covers callbacks actually firing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)