### PR TITLE
Report a channel's scaling as a factor plus its unit

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,6 +32,8 @@ cmake_dependent_option(CBSDK_BUILD_TEST "Build tests" ON
     "CMAKE_SOURCE_DIR STREQUAL PROJECT_SOURCE_DIR" OFF)
 cmake_dependent_option(CBSDK_BUILD_SAMPLE "Build sample applications" ON
     "CMAKE_SOURCE_DIR STREQUAL PROJECT_SOURCE_DIR" OFF)
+cmake_dependent_option(CBSDK_BUILD_TOOLS "Build validation tools" ON
+    "CMAKE_SOURCE_DIR STREQUAL PROJECT_SOURCE_DIR" OFF)
 
 
 ##########################################################################################
@@ -91,8 +93,14 @@ endif(CBSDK_BUILD_TEST)
 
 ##########################################################################################
 # Validation Tools
-add_subdirectory(tools/validate_clock_sync)
-add_subdirectory(tools/rx_bench)
+# Gated like tests and samples: a project consuming CereLink wants the
+# libraries, not our benchmark executables. rx_bench in particular pulls in
+# ccfutils -> pugixml, which breaks a consumer building for an architecture
+# pugixml was not configured for (e.g. a macOS universal binary).
+if(CBSDK_BUILD_TOOLS)
+    add_subdirectory(tools/validate_clock_sync)
+    add_subdirectory(tools/rx_bench)
+endif(CBSDK_BUILD_TOOLS)
 
 ##########################################################################################
 # Sample Applications for New Architecture

--- a/pycbsdk/src/pycbsdk/_cdef.py
+++ b/pycbsdk/src/pycbsdk/_cdef.py
@@ -124,6 +124,17 @@ typedef struct {
     char     anaunit[8];
 } cbsdk_channel_scaling_t;
 
+typedef enum {
+    CBSDK_SCALING_PHYSICAL = 0,
+    CBSDK_SCALING_USER = 1,
+} cbsdk_scaling_source_t;
+
+typedef struct {
+    double scale;
+    double offset;
+    char   unit[9];
+} cbsdk_channel_conversion_t;
+
 ///////////////////////////////////////////////////////////////////////////
 // Callback Types
 ///////////////////////////////////////////////////////////////////////////
@@ -238,6 +249,9 @@ int16_t  cbsdk_session_get_channel_amplrejpos(cbsdk_session_t session, uint32_t 
 int16_t  cbsdk_session_get_channel_amplrejneg(cbsdk_session_t session, uint32_t chan_id);
 cbsdk_result_t cbsdk_session_get_channel_scaling(
     cbsdk_session_t session, uint32_t chan_id, cbsdk_channel_scaling_t* scaling);
+cbsdk_result_t cbsdk_session_get_channel_conversion(
+    cbsdk_session_t session, uint32_t chan_id, cbsdk_scaling_source_t source,
+    cbsdk_channel_conversion_t* conversion);
 
 // Per-channel setters.
 // `auto_sync` is non-zero to run an internal sync() before the read-modify-write

--- a/pycbsdk/src/pycbsdk/session.py
+++ b/pycbsdk/src/pycbsdk/session.py
@@ -861,6 +861,50 @@ class Session:
             "anaunit": ffi.string(scaling.anaunit).decode(),
         }
 
+    def get_channel_conversion(
+        self, chan_id: int, source: str = "physical"
+    ) -> dict | None:
+        """Get a channel's map from raw counts to physical units.
+
+        Prefer this over :meth:`get_channel_scaling` when converting samples: it
+        returns the factor and its unit together, so callers do not have to
+        derive the mapping from the digital/analog ranges. The unit is not
+        uniform across a system -- a Gemini hub's front end reports ``uV`` while
+        a Gemini NSP's analog inputs report ``mV`` -- so it must be read, not
+        assumed.
+
+        ``physical = raw * scale + offset``
+
+        Args:
+            chan_id: 1-based channel ID.
+            source: ``"physical"`` for the ADC's own digitization (default), or
+                ``"user"`` for the user-defined overlay.
+
+        Returns:
+            Dict with keys ``scale``, ``offset``, ``unit``, or ``None`` if the
+            channel is invalid or its scaling record defines no usable map
+            (e.g. an unconfigured channel). ``None`` rather than a neutral 1.0
+            is deliberate: a silent identity scale stores raw counts under a
+            physical unit's name.
+        """
+        _lib = _get_lib()
+        source_value = (
+            _lib.CBSDK_SCALING_USER
+            if str(source).lower() == "user"
+            else _lib.CBSDK_SCALING_PHYSICAL
+        )
+        conversion = ffi.new("cbsdk_channel_conversion_t *")
+        result = _lib.cbsdk_session_get_channel_conversion(
+            self._session, chan_id, source_value, conversion
+        )
+        if result != 0:
+            return None
+        return {
+            "scale": conversion.scale,
+            "offset": conversion.offset,
+            "unit": ffi.string(conversion.unit).decode(),
+        }
+
     def get_channel_field(self, chan_id: int, field: ChanInfoField) -> int:
         """Get any numeric field from a single channel by field selector.
 

--- a/src/cbsdk/include/cbsdk/cbsdk.h
+++ b/src/cbsdk/include/cbsdk/cbsdk.h
@@ -168,6 +168,29 @@ typedef struct {
     char     anaunit[8]; ///< Unit string (e.g., "uV", "mV", "MPa")
 } cbsdk_channel_scaling_t;
 
+/// Which of cbPKT_CHANINFO's two scaling records to read.
+typedef enum {
+    /// physcalin — how the ADC digitizes the input. Converts raw counts to a
+    /// voltage; the right choice for storing or plotting the acquired signal.
+    CBSDK_SCALING_PHYSICAL = 0,
+    /// scalin — a user-defined overlay, e.g. mapping an analog input to a
+    /// transducer's units. Reads the same as physical unless configured.
+    CBSDK_SCALING_USER = 1,
+} cbsdk_scaling_source_t;
+
+/// A channel's linear map from raw counts to physical units:
+///
+///     physical = raw * scale + offset
+///
+/// The unit is returned with the factor because it is not uniform across a
+/// system: a Gemini hub's front end reports "uV" while a Gemini NSP's analog
+/// inputs report "mV".
+typedef struct {
+    double scale;        ///< Physical units per raw count
+    double offset;       ///< Physical units at a raw count of zero
+    char   unit[9];      ///< NUL-terminated copy of anaunit (8 chars + NUL)
+} cbsdk_channel_conversion_t;
+
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 // Callback Types
 ///////////////////////////////////////////////////////////////////////////////////////////////////
@@ -570,6 +593,28 @@ CBSDK_API int16_t cbsdk_session_get_channel_amplrejneg(cbsdk_session_t session, 
 /// @return CBSDK_RESULT_SUCCESS on success, error code otherwise
 CBSDK_API cbsdk_result_t cbsdk_session_get_channel_scaling(
     cbsdk_session_t session, uint32_t chan_id, cbsdk_channel_scaling_t* scaling);
+
+/// Get a channel's map from raw counts to physical units.
+///
+/// Prefer this over cbsdk_session_get_channel_scaling() when you want to
+/// convert samples: it returns the factor and its unit together, so callers do
+/// not have to derive the mapping from the digital/analog ranges themselves.
+///
+/// Fails rather than returning a neutral 1.0 when the channel's scaling record
+/// defines no usable map (zero digital or analog span, typically an
+/// unconfigured channel) — a silent identity scale is how raw counts end up
+/// stored under a physical unit's name.
+///
+/// @param session Session handle (must not be NULL)
+/// @param chan_id 1-based channel ID (1 to cbMAXCHANS)
+/// @param source Which scaling record to read
+/// @param[out] conversion Pointer to struct to fill
+/// @return CBSDK_RESULT_SUCCESS on success, error code otherwise
+CBSDK_API cbsdk_result_t cbsdk_session_get_channel_conversion(
+    cbsdk_session_t session,
+    uint32_t chan_id,
+    cbsdk_scaling_source_t source,
+    cbsdk_channel_conversion_t* conversion);
 
 /// Get any numeric field from a single channel by field selector
 /// @param session Session handle (must not be NULL)

--- a/src/cbsdk/include/cbsdk/sdk_session.h
+++ b/src/cbsdk/include/cbsdk/sdk_session.h
@@ -227,6 +227,56 @@ enum class SampleRate : uint32_t {
 };
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////
+// Channel Scaling
+///////////////////////////////////////////////////////////////////////////////////////////////////
+
+/// Selects which of cbPKT_CHANINFO's two scaling records to read.
+///
+/// A channel carries both. They are frequently identical, but they answer
+/// different questions and only one of them describes the hardware.
+enum class ScalingSource {
+    /// ``physcalin`` — how the ADC digitizes the input. This is the one that
+    /// converts raw counts to a voltage, and the right default for anything
+    /// storing or plotting the acquired signal.
+    Physical,
+    /// ``scalin`` — a user-defined overlay, e.g. mapping an analog input to a
+    /// transducer's units (the field's own docs give "MPa" as an example).
+    /// Reads the same as Physical unless somebody configured it otherwise.
+    User,
+};
+
+/// A channel's linear map from raw counts to physical units:
+///
+///     physical = raw * scale + offset
+///
+/// derived from a cbSCALING record's digital and analog ranges. Callers get the
+/// factor and its unit together, so they never have to assume a unit or know
+/// how the device encodes the mapping.
+struct ChannelScaling {
+    double scale = 1.0;      ///< Physical units per raw count
+    double offset = 0.0;     ///< Physical units at a raw count of zero
+    std::string unit;        ///< Unit of ``scale``/``offset``, verbatim from
+                             ///< ``anaunit`` (e.g. "uV", "mV"). May be empty if
+                             ///< the device left it unset.
+};
+
+/// Derive the count-to-physical-units map from a raw cbSCALING record.
+///
+/// Pure function, exposed so callers holding a cbPKT_CHANINFO already (and
+/// tests) can convert without a session.
+///
+/// ``anagain`` is deliberately ignored: it is documented as the gain applied to
+/// reach the analog values that ``anamin``/``anamax`` already express, so the
+/// range endpoints alone define the map.
+///
+/// @param scaling A cbSCALING record (``physcalin`` or ``scalin``)
+/// @return The scaling, or an error if the record defines no usable map
+///         (zero digital or analog span — typically an unconfigured channel).
+///         An error is returned rather than a neutral 1.0 on purpose: silently
+///         scaling by 1.0 stores raw counts under a physical unit's name.
+Result<ChannelScaling> channelScalingFrom(const cbSCALING& scaling);
+
+///////////////////////////////////////////////////////////////////////////////////////////////////
 // Channel Info Field (for bulk getters)
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 
@@ -437,6 +487,23 @@ public:
     /// @param chan_id 1-based channel ID (1 to cbMAXCHANS)
     /// @return Result containing a copy of the channel info, or an error if invalid/unavailable
     Result<cbPKT_CHANINFO> getChanInfo(uint32_t chan_id) const;
+
+    /// Get a channel's map from raw counts to physical units.
+    ///
+    /// Prefer this over reading cbSCALING out of getChanInfo(): it returns the
+    /// factor together with its unit, so callers do not have to know how the
+    /// device encodes the mapping or assume what unit it is in. The unit is not
+    /// uniform across a system — a Gemini hub's front end reports "uV" while a
+    /// Gemini NSP's analog inputs report "mV" — so the unit must be read, not
+    /// presumed.
+    ///
+    /// @param chan_id 1-based channel ID (1 to cbMAXCHANS)
+    /// @param source Which scaling record to read (defaults to the hardware's)
+    /// @return The scaling, or an error if the channel is unavailable or its
+    ///         scaling record defines no usable map.
+    Result<ChannelScaling> getChanScaling(
+        uint32_t chan_id,
+        ScalingSource source = ScalingSource::Physical) const;
 
     /// Get sample group information
     /// @param group_id Group ID (1-6)

--- a/src/cbsdk/src/cbsdk.cpp
+++ b/src/cbsdk/src/cbsdk.cpp
@@ -18,6 +18,7 @@
 #include <csignal>
 #include <cstdio>
 #include <cstdlib>
+#include <algorithm>
 #include <cstring>
 #include <memory>
 #include <mutex>
@@ -924,6 +925,34 @@ cbsdk_result_t cbsdk_session_get_channel_scaling(
         return CBSDK_RESULT_SUCCESS;
     } catch (...) {
         std::memset(scaling, 0, sizeof(cbsdk_channel_scaling_t));
+        return CBSDK_RESULT_INTERNAL_ERROR;
+    }
+}
+
+cbsdk_result_t cbsdk_session_get_channel_conversion(
+    cbsdk_session_t session,
+    uint32_t chan_id,
+    cbsdk_scaling_source_t source,
+    cbsdk_channel_conversion_t* conversion) {
+    if (!session || !session->cpp_session || !conversion) {
+        return CBSDK_RESULT_INVALID_PARAMETER;
+    }
+    try {
+        auto result = session->cpp_session->getChanScaling(
+            chan_id,
+            source == CBSDK_SCALING_USER ? cbsdk::ScalingSource::User
+                                         : cbsdk::ScalingSource::Physical);
+        if (result.isError()) return CBSDK_RESULT_INVALID_PARAMETER;
+        std::memset(conversion, 0, sizeof(cbsdk_channel_conversion_t));
+        conversion->scale = result.value().scale;
+        conversion->offset = result.value().offset;
+        // unit is 9 bytes for an 8-char anaunit plus a guaranteed terminator.
+        const std::string& unit = result.value().unit;
+        std::memcpy(conversion->unit, unit.data(),
+                    std::min(unit.size(), sizeof(conversion->unit) - 1));
+        return CBSDK_RESULT_SUCCESS;
+    } catch (...) {
+        std::memset(conversion, 0, sizeof(cbsdk_channel_conversion_t));
         return CBSDK_RESULT_INTERNAL_ERROR;
     }
 }

--- a/src/cbsdk/src/sdk_session.cpp
+++ b/src/cbsdk/src/sdk_session.cpp
@@ -1952,6 +1952,49 @@ Result<cbPKT_CHANINFO> SdkSession::getChanInfo(const uint32_t chan_id) const {
     return m_impl->getChanInfo(chan_id);
 }
 
+Result<ChannelScaling> channelScalingFrom(const cbSCALING& scaling) {
+    // Spans are computed in int64 before converting: digmin/digmax are int16 and
+    // anamin/anamax int32, so both differences can overflow their own type.
+    const int64_t dig_span =
+        static_cast<int64_t>(scaling.digmax) - static_cast<int64_t>(scaling.digmin);
+    if (dig_span == 0) {
+        return Result<ChannelScaling>::error(
+            "Channel scaling has a zero digital span (digmin == digmax)");
+    }
+    const int64_t ana_span =
+        static_cast<int64_t>(scaling.anamax) - static_cast<int64_t>(scaling.anamin);
+    if (ana_span == 0) {
+        return Result<ChannelScaling>::error(
+            "Channel scaling has a zero analog span (anamin == anamax)");
+    }
+
+    ChannelScaling out;
+    out.scale = static_cast<double>(ana_span) / static_cast<double>(dig_span);
+    // Equivalent to ``anamin - digmin * scale``, but the numerator is exact in
+    // integer arithmetic, so the symmetric ranges real devices report (e.g.
+    // +/-32767 counts to +/-5000 mV) give exactly 0.0 instead of a rounding
+    // residual. int64 is wide enough: |anamin| < 2^31 and |digmax| < 2^15.
+    const int64_t offset_numerator =
+        static_cast<int64_t>(scaling.anamin) * static_cast<int64_t>(scaling.digmax) -
+        static_cast<int64_t>(scaling.anamax) * static_cast<int64_t>(scaling.digmin);
+    out.offset = static_cast<double>(offset_numerator) / static_cast<double>(dig_span);
+    // anaunit is a fixed-width char buffer that need not be NUL-terminated.
+    out.unit.assign(scaling.anaunit,
+                    strnlen(scaling.anaunit, sizeof(scaling.anaunit)));
+    return Result<ChannelScaling>::ok(out);
+}
+
+Result<ChannelScaling> SdkSession::getChanScaling(
+    const uint32_t chan_id, const ScalingSource source) const {
+    auto info = m_impl->getChanInfo(chan_id);
+    if (info.isError()) {
+        return Result<ChannelScaling>::error(info.error());
+    }
+    const cbSCALING& scaling =
+        source == ScalingSource::User ? info.value().scalin : info.value().physcalin;
+    return channelScalingFrom(scaling);
+}
+
 Result<cbPKT_GROUPINFO> SdkSession::getGroupInfo(uint32_t group_id) const {
     if (group_id == 0 || group_id > cbMAXGROUPS)
         return Result<cbPKT_GROUPINFO>::error("Invalid group ID");

--- a/tests/unit/test_cbsdk_c_compile.c
+++ b/tests/unit/test_cbsdk_c_compile.c
@@ -10,5 +10,15 @@
 int main(void) {
     // Nothing to do here.  Just include cbsdk...
 
+    /* Types that carry data across the C boundary are named here so a change
+     * to their shape or spelling breaks the C build rather than only C++. */
+    cbsdk_channel_conversion_t conversion;
+    cbsdk_scaling_source_t source = CBSDK_SCALING_PHYSICAL;
+    conversion.scale = 1.0;
+    conversion.offset = 0.0;
+    conversion.unit[0] = '\0';
+    (void) source;
+    (void) conversion;
+
     return 0;
 }

--- a/tests/unit/test_sdk_session.cpp
+++ b/tests/unit/test_sdk_session.cpp
@@ -14,6 +14,9 @@
 #include <chrono>
 #include <atomic>
 #include <cstring>  // for memset/memcpy
+#include <algorithm>
+#include <cmath>
+#include <limits>
 
 // Include protocol types and session headers
 #include <cbproto/cbproto.h>            // Protocol types
@@ -469,4 +472,120 @@ TEST_F(SdkSessionTest, TransmitCallback_RoundTrip) {
     printf("  Retrieved payload[5]: 0x%08X\n", retrieved_payload[5]);
     printf("  Original payload[6]: 0x%08X (%u)\n", original_payload[6], original_payload[6]);
     printf("  Retrieved payload[6]: 0x%08X (%u)\n", retrieved_payload[6], retrieved_payload[6]);
+}
+
+///////////////////////////////////////////////////////////////////////////////////////////////////
+// Channel Scaling Tests
+///////////////////////////////////////////////////////////////////////////////////////////////////
+
+namespace {
+
+/// Build a cbSCALING record with the given ranges and unit.
+cbSCALING makeScaling(int16_t digmin, int16_t digmax,
+                      int32_t anamin, int32_t anamax,
+                      const char* unit) {
+    cbSCALING s{};
+    s.digmin = digmin;
+    s.digmax = digmax;
+    s.anamin = anamin;
+    s.anamax = anamax;
+    s.anagain = 1;
+    std::memset(s.anaunit, 0, sizeof(s.anaunit));
+    if (unit) {
+        std::memcpy(s.anaunit, unit, std::min(std::strlen(unit), sizeof(s.anaunit)));
+    }
+    return s;
+}
+
+}  // namespace
+
+// The two range pairs below are the values a Gemini Hub 2 and a Gemini NSP
+// actually report; they are the reason this API returns the unit alongside the
+// factor. Note neither digital span is 2^16, so the factor cannot be assumed
+// from the ADC width.
+TEST_F(SdkSessionTest, ChannelScaling_GeminiHubFrontEnd) {
+    const auto result = channelScalingFrom(makeScaling(-32764, 32764, -8191, 8191, "uV"));
+    ASSERT_TRUE(result.isOk()) << result.error();
+
+    // 16382 uV / 65528 counts == exactly 0.25 uV/count
+    EXPECT_DOUBLE_EQ(result.value().scale, 0.25);
+    EXPECT_DOUBLE_EQ(result.value().offset, 0.0);
+    EXPECT_EQ(result.value().unit, "uV");
+}
+
+TEST_F(SdkSessionTest, ChannelScaling_GeminiNspAnalogIn) {
+    const auto result = channelScalingFrom(makeScaling(-32767, 32767, -5000, 5000, "mV"));
+    ASSERT_TRUE(result.isOk()) << result.error();
+
+    // 10000 mV / 65534 counts -- note the span is 65534, not 2^16
+    EXPECT_DOUBLE_EQ(result.value().scale, 10000.0 / 65534.0);
+    EXPECT_DOUBLE_EQ(result.value().offset, 0.0);
+    EXPECT_EQ(result.value().unit, "mV");
+}
+
+TEST_F(SdkSessionTest, ChannelScaling_AsymmetricRangeYieldsOffset) {
+    // An asymmetric range is what the offset term exists for: 0..65535 counts
+    // mapping to 0..10000 mV puts the zero-count value at 0, but shifting the
+    // analog range moves it.
+    const auto result = channelScalingFrom(makeScaling(0, 1000, 500, 1500, "mV"));
+    ASSERT_TRUE(result.isOk()) << result.error();
+
+    EXPECT_DOUBLE_EQ(result.value().scale, 1.0);
+    EXPECT_DOUBLE_EQ(result.value().offset, 500.0);
+}
+
+TEST_F(SdkSessionTest, ChannelScaling_RoundTripsRangeEndpoints) {
+    const auto result = channelScalingFrom(makeScaling(-32767, 32767, -5000, 5000, "mV"));
+    ASSERT_TRUE(result.isOk()) << result.error();
+    const auto& s = result.value();
+
+    EXPECT_NEAR(-32767 * s.scale + s.offset, -5000.0, 1e-9);
+    EXPECT_NEAR(32767 * s.scale + s.offset, 5000.0, 1e-9);
+    EXPECT_NEAR(0 * s.scale + s.offset, 0.0, 1e-9);
+}
+
+TEST_F(SdkSessionTest, ChannelScaling_UnitNeedNotBeNulTerminated) {
+    // anaunit is a fixed 8-byte field; a unit that fills it has no terminator.
+    cbSCALING s = makeScaling(-32764, 32764, -8191, 8191, nullptr);
+    std::memcpy(s.anaunit, "ABCDEFGH", sizeof(s.anaunit));
+
+    const auto result = channelScalingFrom(s);
+    ASSERT_TRUE(result.isOk()) << result.error();
+    EXPECT_EQ(result.value().unit, "ABCDEFGH");
+    EXPECT_EQ(result.value().unit.size(), sizeof(s.anaunit));
+}
+
+TEST_F(SdkSessionTest, ChannelScaling_EmptyUnitIsAllowed) {
+    const auto result = channelScalingFrom(makeScaling(-32764, 32764, -8191, 8191, nullptr));
+    ASSERT_TRUE(result.isOk()) << result.error();
+    EXPECT_DOUBLE_EQ(result.value().scale, 0.25);
+    EXPECT_TRUE(result.value().unit.empty());
+}
+
+// An unconfigured channel must be an error rather than a neutral 1.0 -- a
+// silent identity scale is how raw counts end up stored under a physical unit.
+TEST_F(SdkSessionTest, ChannelScaling_ZeroDigitalSpanIsAnError) {
+    const auto result = channelScalingFrom(makeScaling(0, 0, -5000, 5000, "mV"));
+    EXPECT_TRUE(result.isError());
+}
+
+TEST_F(SdkSessionTest, ChannelScaling_ZeroAnalogSpanIsAnError) {
+    const auto result = channelScalingFrom(makeScaling(-32767, 32767, 0, 0, "mV"));
+    EXPECT_TRUE(result.isError());
+}
+
+TEST_F(SdkSessionTest, ChannelScaling_AllZeroRecordIsAnError) {
+    cbSCALING s{};
+    EXPECT_TRUE(channelScalingFrom(s).isError());
+}
+
+TEST_F(SdkSessionTest, ChannelScaling_FullInt32RangeDoesNotOverflow) {
+    // anamin/anamax are int32; their difference overflows int32 at the extremes,
+    // so the span must be computed wider.
+    const auto result = channelScalingFrom(makeScaling(
+        -32768, 32767,
+        std::numeric_limits<int32_t>::min(), std::numeric_limits<int32_t>::max(), "V"));
+    ASSERT_TRUE(result.isOk()) << result.error();
+    EXPECT_GT(result.value().scale, 0.0);
+    EXPECT_TRUE(std::isfinite(result.value().scale));
 }


### PR DESCRIPTION
## Why

`cbPKT_CHANINFO` carries the raw ingredients of a channel's count-to-physical map, but every caller wanting to convert samples had to reassemble them from `digmin`/`digmax` against `anamin`/`anamax` — and guess at the unit.

That guess is the problem. Measured on real hardware:

| Device | Channel class | Reports | Per count |
| --- | --- | --- | --- |
| Gemini Hub 2 | `FRONTEND` (256 ch) | ±32764 ct ↔ ±8191 `uV` | 0.25 µV |
| Gemini NSP | `ANALOG_IN` (16 ch) | ±32767 ct ↔ ±5000 `mV` | 0.152593 mV |

The unit is **not uniform across a system**, so assuming microvolts is off by 1000x on analog in. And neither digital span is 2<sup>16</sup> — 65528 and 65534 — so the factor cannot be inferred from the ADC width either. A downstream consumer hardcoding `10/2^16` for the NSP is ~31 ppm off.

## What

`SdkSession::getChanScaling(chan_id, source)` returns `scale`, `offset` and `unit` together:

```
physical = raw * scale + offset
```

`ScalingSource` selects between `physcalin` (how the ADC digitizes — the default) and `scalin` (a user-defined transducer overlay). These are distinct fields and only the former describes the hardware; they read identically on the devices tested. Note the pre-existing C `cbsdk_session_get_channel_scaling()` reads `scalin`; it is unchanged.

The arithmetic lives in a free function, `channelScalingFrom(const cbSCALING&)`, so callers already holding a `cbPKT_CHANINFO` can convert without a session, and the math is testable without hardware.

Mirrored into the C API as `cbsdk_session_get_channel_conversion()` and pycbsdk as `Session.get_channel_conversion()`.

### Two deliberate choices

- **`anagain` is ignored.** It is documented as the gain applied to reach the analog values `anamin`/`anamax` already express, so the range endpoints alone define the map. It reads `1` on both devices tested. Silently multiplying by a field never exercised seemed worse than documenting the omission.
- **A zero digital or analog span is an error, not a neutral 1.0.** An unconfigured channel silently scaling by 1.0 is exactly how raw counts end up stored under a physical unit's name.

The offset numerator is computed in integer arithmetic (`anamin*digmax - anamax*digmin`) so the symmetric ranges real devices report resolve to exactly `0.0`; the obvious `anamin - digmin*scale` leaves a `-2.3e-13` residual on the NSP.

## Second commit: stop building the validation tools for consumers

Unrelated but needed for the same downstream release, and separable if you'd rather it went on its own.

Tests and samples are gated on `cmake_dependent_option` so they resolve to OFF when CereLink is not the top-level project. `tools/` was added later without the same guard, so every consumer built `validate_clock_sync` and `rx_bench` alongside the libraries it asked for. `rx_bench` links `ccfutils` → `pugixml`, so a consumer building for an architecture pugixml was not configured for fails to link — Orion hit this building a macOS universal binary. Adds `CBSDK_BUILD_TOOLS` following the existing pattern; standalone builds are unaffected.

## Testing

- 10 new unit tests covering both devices' real range values, asymmetric ranges producing a non-zero offset, endpoint round-tripping, a non-NUL-terminated `anaunit`, the zero-span error paths, and int32 span overflow.
- Verified end-to-end against a live Gemini Hub 2 and Gemini NSP through all three layers (C++, C API, pycbsdk), 272 channels, zero errors.
- Verified the tools still build standalone and no longer appear in a consumer's generated build.

Pre-existing unrelated failures in `CbsdkCApiTest`/`SdkSessionTest` (24) are unchanged — confirmed identical on a clean tree; they need a loopback device that was not running.

🤖 Generated with [Claude Code](https://claude.com/claude-code)